### PR TITLE
Repository Scanner

### DIFF
--- a/repo-scanner/README.md
+++ b/repo-scanner/README.md
@@ -1,0 +1,98 @@
+# SecurityTools - RepoScanner
+
+This tool can be used to create a database of artifacts available in given set of source repositories. Gathered information will include:
+* Repository Type
+* Repository Name
+* Repository URL
+* Tag Name
+* Tag Download URL (ZIP)
+* Artifact ID
+* Group ID
+* Packaging 
+* Version
+* Maven Final Name
+* Path of Artifact within Repository 
+
+Note: This repository is under active development. 
+
+## Support
+### Repositories
+* GitHub
+### Build Configuration
+* Maven
+### Storage
+* JDBC
+
+## Build
+```
+mvn clean install 
+```
+## Usage 
+Note: Passwords and OAuth2 Tokens are requested as command line inputs.
+```
+-------------------------------------------------
+-----                                       -----
+-----          Repository Scanner           -----
+-----                                       -----
+-------------------------------------------------
+Usage: Repo Scanner [options]
+  Options:
+    -git.oauth2
+      OAuth token used to access GitHub
+    -git.users
+      Comma separated list of GitHub user accounts to scan
+    -maven.home
+      Maven home (if environment variables are not set)
+    -storage
+      Storage used in storing final results (Options: JDBC) (Default: JDBC)
+    -jdbc.driver
+      Database driver class (Default: com.mysql.jdbc.Driver)
+    -jdbc.url
+      Database connection URL (Default: jdbc:mysql://localhost/RepoScanner)
+    -jdbc.username
+      Database username (Default: root)
+    -jdbc.password
+      Database password
+    -jdbc.dialect
+      Database Hibernate dialect (Default: org.hibernate.dialect.MySQLDialect)
+    -verbose, -v
+      Verbose output
+      Default: false
+    -debug, -d
+      Verbose + Debug output for debugging requirements
+      Default: false
+    --help, -help, -?
+
+    -jdbc.create
+      Drop and create JDBC tables
+      Default: false
+    -rescan
+      Rescan repo-tag combinaions even if they are already indexed. (Default:
+      false)
+      Default: false
+    -downloadMaster
+      Download master branches of all repositories locally
+      Default: false
+    -downloadTags
+      Download all tags of all repositories locally
+      Default: false
+    -skipScan
+      Skip scanning process. Usable when -downloadMaster and -downloadTag
+      options are required without scanning.
+      Default: false
+```
+## Usage Examples
+Scan GIT all repositories from "wso2" and "wso2-extensions" GitHub account
+```
+java -jar RepoScanner-1.0-SNAPSHOT.jar -git.oauth2 -jdbc.password -jdbc.username MySQLUser -git.users wso2,wso2-extensions
+```
+
+Skip the scanning process and download source code from master branches of all repositories from "wso2" and "wso2-extensions" GitHub account.
+```
+java -jar RepoScanner-1.0-SNAPSHOT.jar -git.oauth2 -jdbc.password -jdbc.username MySQLUser -git.users wso2,wso2-extensions -skipScan -downloadMaster
+```
+
+Skip the scanning process and download source code from master branches and tags of all repositories from "wso2" and "wso2-extensions" GitHub account.
+```
+java -jar RepoScanner-1.0-SNAPSHOT.jar -git.oauth2 -jdbc.password -jdbc.username MySQLUser -git.users wso2,wso2-extensions -skipScan -downloadMaster -downloadTags
+```

--- a/repo-scanner/pom.xml
+++ b/repo-scanner/pom.xml
@@ -1,0 +1,121 @@
+<!--
+Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.security.tools.git.repo.scanner</groupId>
+    <artifactId>org.wso2.security.tools.git.repo.scanner</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mylyn.github</groupId>
+            <artifactId>org.eclipse.egit.github.core</artifactId>
+            <version>2.1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>4.6.1.201703071140-r</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.cbeust</groupId>
+            <artifactId>jcommander</artifactId>
+            <version>1.66</version>
+        </dependency>
+        <dependency>
+            <groupId>org.zeroturnaround</groupId>
+            <artifactId>zt-zip</artifactId>
+            <version>1.11</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
+            <version>2.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.1.5.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.41</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-log</artifactId>
+            <version>0.17.1</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.wso2.security.tools.reposcanner.Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/AppConfig.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/AppConfig.java
@@ -1,0 +1,133 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AppConfig {
+    private static boolean verbose;
+    private static boolean debug;
+    private static boolean createDB;
+    private static boolean rescanRepos;
+    private static boolean downloadMaster;
+    private static boolean downloadTags;
+    private static boolean skipScan;
+
+    private static String mavenHome;
+    private static List<String> githubAccounts;
+    private static List<String> mavenOutputSkipPatterns;
+
+    public static boolean isVerbose() {
+        return verbose;
+    }
+
+    public static void setVerbose(boolean verbose) {
+        AppConfig.verbose = verbose;
+    }
+
+    public static boolean isDebug() {
+        return debug;
+    }
+
+    public static void setDebug(boolean debug) {
+        AppConfig.debug = debug;
+    }
+
+    public static boolean isCreateDB() {
+        return createDB;
+    }
+
+    public static void setCreateDB(boolean createDB) {
+        AppConfig.createDB = createDB;
+    }
+
+    public static boolean isRescanRepos() {
+        return rescanRepos;
+    }
+
+    public static void setRescanRepos(boolean rescanRepos) {
+        AppConfig.rescanRepos = rescanRepos;
+    }
+
+    public static String getMavenHome() {
+        return mavenHome;
+    }
+
+    public static void setMavenHome(String mavenHome) {
+        AppConfig.mavenHome = mavenHome;
+    }
+
+    public static List<String> getGithubAccounts() {
+        return githubAccounts;
+    }
+
+    public static void setGithubAccounts(List<String> githubAccounts) {
+        AppConfig.githubAccounts = githubAccounts;
+    }
+
+    public static void addGithubAccount(String githubAccount) {
+        if (AppConfig.githubAccounts == null) {
+            AppConfig.githubAccounts = new ArrayList<>();
+        }
+        AppConfig.githubAccounts.add(githubAccount);
+    }
+
+    public static List<String> getMavenOutputSkipPatterns() {
+        return mavenOutputSkipPatterns;
+    }
+
+    public static void setMavenOutputSkipPatterns(List<String> mavenOutputSkipPatterns) {
+        AppConfig.mavenOutputSkipPatterns = mavenOutputSkipPatterns;
+    }
+
+    public static void addMavenOutputSkipPattern(String mavenOutputSkipPattern) {
+        if (AppConfig.mavenOutputSkipPatterns == null) {
+            AppConfig.mavenOutputSkipPatterns = new ArrayList<>();
+        }
+        AppConfig.mavenOutputSkipPatterns.add(mavenOutputSkipPattern);
+    }
+
+    static {
+        AppConfig.addMavenOutputSkipPattern("[");
+        AppConfig.addMavenOutputSkipPattern("Download");
+    }
+
+    public static boolean isDownloadMaster() {
+        return downloadMaster;
+    }
+
+    public static void setDownloadMaster(boolean downloadMaster) {
+        AppConfig.downloadMaster = downloadMaster;
+    }
+
+    public static boolean isDownloadTags() {
+        return downloadTags;
+    }
+
+    public static void setDownloadTags(boolean downloadTags) {
+        AppConfig.downloadTags = downloadTags;
+    }
+
+    public static boolean isSkipScan() {
+        return skipScan;
+    }
+
+    public static void setSkipScan(boolean skipScan) {
+        AppConfig.skipScan = skipScan;
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/Main.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/Main.java
@@ -1,0 +1,177 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import org.apache.log4j.Logger;
+import org.wso2.security.tools.reposcanner.scanner.GitHubRepoScanner;
+import org.wso2.security.tools.reposcanner.scanner.RepoScanner;
+import org.wso2.security.tools.reposcanner.storage.JDBCStorage;
+import org.wso2.security.tools.reposcanner.storage.Storage;
+
+public class Main {
+    private static Logger log = Logger.getLogger(Main.class.getName());
+
+    @Parameter(names = {"-git.oauth2"}, description = "OAuth token used to access GitHub", password = true, order = 1)
+    private String gitOAuth2Token;
+
+    @Parameter(names = {"-git.users"}, description = "Comma separated list of GitHub user accounts to scan", order = 2)
+    private String gitUserAccounts;
+
+    @Parameter(names = {"-maven.home"}, description = "Maven home (if environment variables are not set)", order = 3)
+    private String mavenHome;
+
+    @Parameter(names = {"-storage"}, description = "Storage used in storing final results (Options: JDBC) (Default: JDBC)", order = 4)
+    private String storageType;
+
+    @Parameter(names = {"-jdbc.driver"}, description = "Database driver class (Default: com.mysql.jdbc.Driver)", order = 5)
+    private String databaseDriver;
+
+    @Parameter(names = {"-jdbc.url"}, description = "Database connection URL (Default: jdbc:mysql://localhost/RepoScanner)", order = 6)
+    private String databaseUrl;
+
+    @Parameter(names = {"-jdbc.username"}, description = "Database username (Default: root)", order = 7)
+    private String databaseUsername;
+
+    @Parameter(names = {"-jdbc.password"}, description = "Database password", password = true, order = 8)
+    private String databasePassword;
+
+    @Parameter(names = {"-jdbc.dialect"}, description = "Database Hibernate dialect (Default: org.hibernate.dialect.MySQLDialect)", order = 9)
+    private String databaseHibernateDialect;
+
+    @Parameter(names = {"-verbose", "-v"}, description = "Verbose output", order = 10)
+    private boolean verbose;
+
+    @Parameter(names = {"-debug", "-d"}, description = "Verbose + Debug output for debugging requirements", order = 11)
+    private boolean debug;
+
+    @Parameter(names = {"--help", "-help", "-?"}, help = true, order = 12)
+    private boolean help;
+
+    @Parameter(names = {"-jdbc.create"}, description = "Drop and create JDBC tables", order = 13)
+    private boolean databaseCreate;
+
+    @Parameter(names = {"-rescan"}, description = "Rescan repo-tag combinaions even if they are already indexed. (Default: false)", order = 16)
+    private boolean rescan;
+
+    @Parameter(names = {"-downloadMaster"}, description = "Download master branches of all repositories locally", order = 17)
+    private boolean downloadMaster;
+
+    @Parameter(names = {"-downloadTags"}, description = "Download all tags of all repositories locally", order = 18)
+    private boolean downloadTags;
+
+    @Parameter(names = {"-skipScan"}, description = "Skip scanning process. Usable when -downloadMaster and -downloadTag options are required without scanning.", order = 18)
+    private boolean skipScan;
+
+    public static void main(String[] args) throws Exception {
+        Main main = new Main();
+
+        log.info("-------------------------------------------------");
+        log.info("-----                                       -----");
+        log.info("-----          Repository Scanner           -----");
+        log.info("-----                                       -----");
+        log.info("-------------------------------------------------");
+
+        JCommander jCommander = new JCommander(main, args);
+        jCommander.setProgramName("Repo Scanner");
+
+        if (main.help) {
+            jCommander.usage();
+            return;
+        }
+
+        if (main.databaseDriver == null || main.databaseDriver.length() == 0) {
+            main.databaseDriver = "com.mysql.jdbc.Driver";
+        }
+        if (main.databaseUrl == null || main.databaseUrl.length() == 0) {
+            main.databaseUrl = "jdbc:mysql://localhost/RepoScanner";
+        }
+        if (main.databaseUsername == null || main.databaseUsername.length() == 0) {
+            main.databaseUsername = "root";
+        }
+        if (main.databaseHibernateDialect == null || main.databaseHibernateDialect.length() == 0) {
+            main.databaseHibernateDialect = "org.hibernate.dialect.MySQLDialect";
+        }
+        if (main.storageType == null || main.storageType.length() == 0) {
+            main.storageType = "JDBC";
+        }
+
+        main.start(jCommander);
+    }
+
+    public void start(JCommander jCommander) {
+        if (gitUserAccounts != null) {
+            for (String user : gitUserAccounts.split(",")) {
+                AppConfig.addGithubAccount(user);
+            }
+        }
+
+        AppConfig.setMavenHome(mavenHome);
+        AppConfig.setVerbose(verbose);
+        if (debug) {
+            AppConfig.setVerbose(true);
+            AppConfig.setDebug(true);
+        }
+        AppConfig.setCreateDB(databaseCreate);
+        AppConfig.setRescanRepos(rescan);
+        AppConfig.setDownloadMaster(downloadMaster);
+        AppConfig.setDownloadTags(downloadTags);
+        AppConfig.setSkipScan(skipScan);
+
+        if (rescan) {
+            log.warn("Full repository re-scan in progress. Scan will take additional time.");
+        }
+
+        Storage storage = null;
+        if (!AppConfig.isSkipScan()) {
+            if (storageType.equals("JDBC")) {
+                if (databaseDriver == null || databaseUrl == null || databaseUsername == null || databasePassword == null || databaseHibernateDialect == null) {
+                    log.error("JDBC parameters are not properly set (All -jdbc parameters are required). Terminating...");
+                    jCommander.usage();
+                    return;
+                }
+                storage = new JDBCStorage(databaseDriver, databaseUrl, databaseUsername, databasePassword.toCharArray(), databaseHibernateDialect);
+            } else {
+                log.error("No valid storage option selected. Terminating...");
+                jCommander.usage();
+                return;
+            }
+        } else {
+            log.warn("[Skipping] SkipScan parameter is set. Skipping database connection initialization.");
+        }
+
+        if (gitOAuth2Token != null) {
+            try {
+                RepoScanner scanner = new GitHubRepoScanner(gitOAuth2Token.toCharArray());
+                scanner.scan(storage);
+
+                //Any other scanners should be added here to make sure storage is closed only after all the scanners are complete
+
+                log.info("Scanning complete. Terminating...");
+            } catch (Exception e) {
+                log.fatal("Exception occured during scanning process. Terminating...", e);
+            } finally {
+                storage.close();
+            }
+        } else {
+            log.error("No scanning parameters are set. Please use \"-git.oauth2\" parameter to set OAuth credentials to access GitHub account. Terminating...");
+            jCommander.usage();
+            storage.close();
+        }
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/artifact/ArtifactInfoGenerator.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/artifact/ArtifactInfoGenerator.java
@@ -1,0 +1,26 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.artifact;
+
+import org.wso2.security.tools.reposcanner.entiry.Repo;
+import org.wso2.security.tools.reposcanner.entiry.RepoArtifact;
+
+import java.io.File;
+
+public interface ArtifactInfoGenerator {
+    public RepoArtifact getArtifact(String consoleTag, Repo repo, File baseFolder, File configFile) throws Exception;
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/artifact/MavenArtifactInfoGenerator.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/artifact/MavenArtifactInfoGenerator.java
@@ -1,0 +1,106 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.artifact;
+
+import org.apache.log4j.Logger;
+import org.apache.maven.shared.invoker.*;
+import org.wso2.security.tools.reposcanner.AppConfig;
+import org.wso2.security.tools.reposcanner.entiry.Repo;
+import org.wso2.security.tools.reposcanner.entiry.RepoArtifact;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+public class MavenArtifactInfoGenerator implements ArtifactInfoGenerator {
+    private static Logger log = Logger.getLogger(MavenArtifactInfoGenerator.class.getName());
+
+    @Override
+    public RepoArtifact getArtifact(String consoleTag, Repo repo, File baseFolder, File configFile) throws MavenInvocationException {
+        String path = configFile.getAbsolutePath().substring(baseFolder.getAbsolutePath().length(), configFile.getAbsolutePath().length());
+
+        log.info(consoleTag + "Calling MavenID and FinalName identification process for path: " + path);
+
+        String id = runMavenExpression(consoleTag, configFile, "-Dexpression=project.id");
+        String finalName = runMavenExpression(consoleTag, configFile, "-Dexpression=project.build.finalName");
+
+        if (id != null && id.split(":").length == 4) {
+            log.info(consoleTag + "MavenID for path \"" + path + "\" is " + id);
+            log.info(consoleTag + "FinalName for path \"" + path + "\" is " + finalName);
+
+            path = path.substring(path.indexOf(File.separator, 1), path.length());
+            path = path.replace("pom.xml", "");
+
+            RepoArtifact mavenInfo = new RepoArtifact(repo, path, id, finalName);
+            return mavenInfo;
+        } else {
+            throw new IllegalArgumentException("Invalid or incomplete MavenID (" + id + ") for path: " + path);
+        }
+    }
+
+    private String runMavenExpression(String consoleTag, File baseFile, String expression) throws MavenInvocationException {
+        Properties props = System.getProperties();
+
+        props.setProperty("maven.home", AppConfig.getMavenHome());
+
+        MavenIdInvocationOutputHandler handler = new MavenIdInvocationOutputHandler(consoleTag);
+        InvocationRequest request = new DefaultInvocationRequest();
+        request.setOutputHandler(handler);
+        request.setPomFile(baseFile);
+        request.setGoals(Arrays.asList("org.apache.maven.plugins:maven-help-plugin:evaluate", expression));
+
+        Invoker invoker = new DefaultInvoker();
+        invoker.execute(request);
+
+        return handler.getMavenId();
+    }
+
+    private static class MavenIdInvocationOutputHandler implements InvocationOutputHandler {
+        private String mavenId;
+        private String consoleTag;
+
+        public MavenIdInvocationOutputHandler(String consoleTag) {
+            this.consoleTag = consoleTag;
+        }
+
+        public void consumeLine(String s) {
+            if (AppConfig.isDebug()) {
+                log.debug(consoleTag + "[MavenInvocation] " + s);
+            }
+
+            List<String> mavenOutputSkipPatterns = AppConfig.getMavenOutputSkipPatterns();
+            boolean isConsumable = true;
+            for (String mavenOutputSkipPattern : mavenOutputSkipPatterns) {
+                if (s.startsWith(mavenOutputSkipPattern)) {
+                    isConsumable = false;
+                }
+            }
+            if (isConsumable && !(s.contains("null object") || s.contains("invalid expression"))) {
+                mavenId = s;
+            }
+        }
+
+        public String getMavenId() {
+            return mavenId;
+        }
+
+        public void setMavenId(String mavenId) {
+            this.mavenId = mavenId;
+        }
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/downloader/DownloadUtil.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/downloader/DownloadUtil.java
@@ -1,0 +1,33 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.downloader;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+
+public class DownloadUtil {
+    protected static void downloadFile(String sourceUrl, File destinationFile) throws IOException {
+        URL website = new URL(sourceUrl);
+        ReadableByteChannel rbc = Channels.newChannel(website.openStream());
+        FileOutputStream fos = new FileOutputStream(destinationFile);
+        fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/downloader/GitHubMasterDownloader.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/downloader/GitHubMasterDownloader.java
@@ -1,0 +1,33 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.downloader;
+
+import org.wso2.security.tools.reposcanner.entiry.Repo;
+import org.zeroturnaround.zip.ZipUtil;
+
+import java.io.File;
+
+public class GitHubMasterDownloader implements RepoDownloader {
+    @Override
+    public void downloadRepo(Repo repo, File destinationFolder, boolean unzip) throws Exception {
+        File tempZipFile = new File(destinationFolder.getAbsoluteFile() + File.separator + repo.getRepositoryName() + "-master.zip");
+        DownloadUtil.downloadFile("https://github.com/" + repo.getUser() + "/" + repo.getRepositoryName() + "/archive/master.zip", tempZipFile);
+        if (unzip) {
+            ZipUtil.unpack(tempZipFile, destinationFolder);
+        }
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/downloader/GitHubTagDownloader.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/downloader/GitHubTagDownloader.java
@@ -1,0 +1,34 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.downloader;
+
+import org.wso2.security.tools.reposcanner.entiry.Repo;
+import org.zeroturnaround.zip.ZipUtil;
+
+import java.io.File;
+import java.io.IOException;
+
+public class GitHubTagDownloader implements RepoDownloader {
+    @Override
+    public void downloadRepo(Repo repo, File destinationFolder, boolean unzip) throws IOException {
+        File tempZipFile = new File(destinationFolder.getAbsoluteFile() + File.separator + repo.getRepositoryName() + "-Tag-" + repo.getTagName() + ".zip");
+        DownloadUtil.downloadFile(repo.getTagZip(), tempZipFile);
+        if (unzip) {
+            ZipUtil.unpack(tempZipFile, destinationFolder);
+        }
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/downloader/RepoDownloader.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/downloader/RepoDownloader.java
@@ -1,0 +1,29 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.downloader;
+
+import org.wso2.security.tools.reposcanner.entiry.Repo;
+
+import java.io.File;
+
+public interface RepoDownloader {
+    public void downloadRepo(Repo repo, File destinationFolder, boolean unzip) throws Exception;
+
+    default void downloadRepo(Repo repo, File destinationFolder) throws Exception {
+        downloadRepo(repo, destinationFolder, true);
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/entiry/Repo.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/entiry/Repo.java
@@ -1,0 +1,144 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.entiry;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Table(name = "REPO", indexes = {@Index(columnList = "REPO_NAME,TAG_NAME", name = "repoName_tagName_idx")})
+public class Repo {
+    @Id
+    @Column(name = "ID")
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "repo_info_seq_gen")
+    @SequenceGenerator(name = "repo_info_seq_gen", sequenceName = "REPO_INFO_SEQ")
+    private Long id;
+
+    @Column(name = "REPO_TYPE", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private RepoType repoType;
+
+    @Column(name = "USER", nullable = false)
+    private String user;
+
+    @Column(name = "REPO_NAME", nullable = false)
+    private String repositoryName;
+
+    @Column(name = "REPO_URL", nullable = false, length = 2048)
+    private String repositoryUrl;
+
+    @Column(name = "TAG_NAME", nullable = false)
+    private String tagName;
+
+    @Column(name = "TAG_ZIP", nullable = false, length = 2048)
+    private String tagZip;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "ADDED_DATE")
+    private Date addedDate;
+
+    public Repo(RepoType repoType, String user, String repositoryName, String repositoryUrl, String tagName, String tagZip, Date addedDate) {
+        this.repoType = repoType;
+        this.user = user;
+        this.repositoryName = repositoryName;
+        this.repositoryUrl = repositoryUrl;
+        this.tagName = tagName;
+        this.tagZip = tagZip;
+        this.addedDate = addedDate;
+    }
+
+    public Repo() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public RepoType getRepoType() {
+        return repoType;
+    }
+
+    public void setRepoType(RepoType repoType) {
+        this.repoType = repoType;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getRepositoryName() {
+        return repositoryName;
+    }
+
+    public void setRepositoryName(String repositoryName) {
+        this.repositoryName = repositoryName;
+    }
+
+    public String getRepositoryUrl() {
+        return repositoryUrl;
+    }
+
+    public void setRepositoryUrl(String repositoryUrl) {
+        this.repositoryUrl = repositoryUrl;
+    }
+
+    public String getTagName() {
+        return tagName;
+    }
+
+    public void setTagName(String tagName) {
+        this.tagName = tagName;
+    }
+
+    public String getTagZip() {
+        return tagZip;
+    }
+
+    public void setTagZip(String tagZip) {
+        this.tagZip = tagZip;
+    }
+
+    public Date getAddedDate() {
+        return addedDate;
+    }
+
+    public void setAddedDate(Date addedDate) {
+        this.addedDate = addedDate;
+    }
+
+    @Override
+    public String toString() {
+        return "Repo{" +
+                "id=" + id +
+                ", repoType=" + repoType +
+                ", user='" + user + '\'' +
+                ", repositoryName='" + repositoryName + '\'' +
+                ", repositoryUrl='" + repositoryUrl + '\'' +
+                ", tagName='" + tagName + '\'' +
+                ", tagZip='" + tagZip + '\'' +
+                ", addedDate=" + addedDate +
+                '}';
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/entiry/RepoArtifact.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/entiry/RepoArtifact.java
@@ -1,0 +1,158 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.entiry;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Table(name = "REPO_ARTIFACT", indexes = {@Index(columnList = "PATH", name = "artifact_path_idx")})
+public class RepoArtifact {
+    @Id
+    @Column(name = "ID")
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "artifact_info_seq_gen")
+    @SequenceGenerator(name = "artifact_info_seq_gen", sequenceName = "ARTIFACT_INFO_SEQ")
+    private Long id;
+
+    @Column(name = "PATH", nullable = false, length = 2048)
+    private String path;
+
+    @Column(name = "GROUP_ID", nullable = false)
+    private String groupId;
+
+    @Column(name = "ARTIFACT_ID", nullable = false)
+    private String artifactId;
+
+    @Column(name = "PACKAGING", nullable = false)
+    private String packaging;
+
+    @Column(name = "VERSION", nullable = false)
+    private String version;
+
+    @Column(name = "FINAL_NAME")
+    private String finalName;
+
+    @ManyToOne
+    @JoinColumn(name = "REPO_INFO_ID", nullable = false)
+    private Repo repo;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "ADDED_DATE")
+    private Date addedDate;
+
+    public RepoArtifact(Repo repo, String path, String mavenId, String finalName) {
+        String[] mavenIdParts = mavenId.split(":");
+        this.path = path;
+        this.groupId = mavenIdParts[0];
+        this.artifactId = mavenIdParts[1];
+        this.packaging = mavenIdParts[2];
+        this.version = mavenIdParts[3];
+        this.repo = repo;
+        this.addedDate = new Date();
+        this.finalName = finalName;
+    }
+
+    public RepoArtifact() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    public String getPackaging() {
+        return packaging;
+    }
+
+    public void setPackaging(String packaging) {
+        this.packaging = packaging;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getFinalName() {
+        return finalName;
+    }
+
+    public void setFinalName(String finalName) {
+        this.finalName = finalName;
+    }
+
+    public Repo getRepo() {
+        return repo;
+    }
+
+    public void setRepo(Repo repo) {
+        this.repo = repo;
+    }
+
+    public Date getAddedDate() {
+        return addedDate;
+    }
+
+    public void setAddedDate(Date addedDate) {
+        this.addedDate = addedDate;
+    }
+
+    @Override
+    public String toString() {
+        return "RepoArtifact{" +
+                "id=" + id +
+                ", path='" + path + '\'' +
+                ", groupId='" + groupId + '\'' +
+                ", artifactId='" + artifactId + '\'' +
+                ", packaging='" + packaging + '\'' +
+                ", version='" + version + '\'' +
+                ", finalName='" + finalName + '\'' +
+                ", repo=" + repo +
+                ", addedDate=" + addedDate +
+                '}';
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/entiry/RepoError.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/entiry/RepoError.java
@@ -1,0 +1,105 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.entiry;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Table(name = "REPO_ERROR")
+public class RepoError {
+    @Id
+    @Column(name = "ID")
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "error_info_seq_gen")
+    @SequenceGenerator(name = "error_info_seq_gen", sequenceName = "ERROR_INFO_SEQ")
+    private Long id;
+
+    @Column(name = "BUILD_CONFIG", length = 2048)
+    private String buildConfigLocation;
+
+    @Column(name = "ERROR_REASON")
+    private String errorReason;
+
+    @ManyToOne
+    @JoinColumn(name = "REPO_INFO_ID", nullable = false)
+    private Repo repo;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "ADDED_DATE")
+    private Date addedDate;
+
+    public RepoError(String buildConfigLocation, String errorReason, Repo repo, Date addedDate) {
+        this.buildConfigLocation = buildConfigLocation;
+        this.errorReason = errorReason;
+        this.repo = repo;
+        this.addedDate = addedDate;
+    }
+
+    public RepoError() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getBuildConfigLocation() {
+        return buildConfigLocation;
+    }
+
+    public void setBuildConfigLocation(String buildConfigLocation) {
+        this.buildConfigLocation = buildConfigLocation;
+    }
+
+    public String getErrorReason() {
+        return errorReason;
+    }
+
+    public void setErrorReason(String errorReason) {
+        this.errorReason = errorReason;
+    }
+
+    public Repo getRepo() {
+        return repo;
+    }
+
+    public void setRepo(Repo repo) {
+        this.repo = repo;
+    }
+
+    public Date getAddedDate() {
+        return addedDate;
+    }
+
+    public void setAddedDate(Date addedDate) {
+        this.addedDate = addedDate;
+    }
+
+    @Override
+    public String toString() {
+        return "RepoError{" +
+                "id=" + id +
+                ", buildConfigLocation='" + buildConfigLocation + '\'' +
+                ", errorReason='" + errorReason + '\'' +
+                ", repo=" + repo +
+                ", addedDate=" + addedDate +
+                '}';
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/entiry/RepoType.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/entiry/RepoType.java
@@ -1,0 +1,21 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.entiry;
+
+public enum RepoType {
+    GIT
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/repository/GitHubRepoInfoGenerator.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/repository/GitHubRepoInfoGenerator.java
@@ -1,0 +1,144 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.repository;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+import org.eclipse.egit.github.core.Repository;
+import org.eclipse.egit.github.core.RepositoryTag;
+import org.eclipse.egit.github.core.client.GitHubClient;
+import org.eclipse.egit.github.core.service.RepositoryService;
+import org.wso2.security.tools.reposcanner.AppConfig;
+import org.wso2.security.tools.reposcanner.downloader.GitHubMasterDownloader;
+import org.wso2.security.tools.reposcanner.downloader.GitHubTagDownloader;
+import org.wso2.security.tools.reposcanner.downloader.RepoDownloader;
+import org.wso2.security.tools.reposcanner.entiry.Repo;
+import org.wso2.security.tools.reposcanner.entiry.RepoType;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+public class GitHubRepoInfoGenerator implements RepoInfoGenerator {
+    private static Logger log = Logger.getLogger(GitHubRepoInfoGenerator.class.getName());
+
+    private GitHubClient client;
+
+    private RepoDownloader gitMasterDownloader;
+    private File masterDownloadFolder;
+
+    private RepoDownloader gitTagDownloader;
+    private File tagsDownloadFolder;
+
+    public GitHubRepoInfoGenerator(char[] oAuth2Token) {
+        client = new GitHubClient();
+        client.setOAuth2Token(new String(oAuth2Token));
+
+        if (AppConfig.isDownloadMaster()) {
+            gitMasterDownloader = new GitHubMasterDownloader();
+            masterDownloadFolder = new File("source-master");
+            if (masterDownloadFolder.exists()) {
+                try {
+                    FileUtils.deleteDirectory(masterDownloadFolder);
+                } catch (IOException e) {
+                    log.error("Error in removing master download folder: " + masterDownloadFolder.getAbsolutePath(), e);
+                }
+            }
+            masterDownloadFolder.mkdir();
+        }
+
+        if (AppConfig.isDownloadTags()) {
+            gitTagDownloader = new GitHubTagDownloader();
+            tagsDownloadFolder = new File("source-tags");
+            if (tagsDownloadFolder.exists()) {
+                try {
+                    FileUtils.deleteDirectory(tagsDownloadFolder);
+                } catch (IOException e) {
+                    log.error("Error in removing tags download folder: " + tagsDownloadFolder.getAbsolutePath(), e);
+                }
+            }
+            tagsDownloadFolder.mkdir();
+        }
+    }
+
+    @Override
+    public List<Repo> getRepoList(String consoleTag, List<String> users) {
+        RepositoryService repositoryService = new RepositoryService(client);
+        List<Repo> repoList = Collections.synchronizedList(new ArrayList());
+
+        //Get the list of git repositories for each GitHub user account
+        users.parallelStream().forEach(user -> {
+            log.info(consoleTag + "Fetching repositories for GitHub user account: " + user);
+            try {
+                List<Repository> userRepositoryList = repositoryService.getRepositories(user);
+                log.info(consoleTag + userRepositoryList.size() + " repositories found for user account: " + user);
+
+                if (AppConfig.isDownloadMaster()) {
+                    userRepositoryList.parallelStream().forEach(repository -> {
+                        try {
+                            log.info(consoleTag + "[DownloadMaster] Started downloading master branch of: " + repository.getName());
+                            Repo tempRepo = new Repo(RepoType.GIT, repository.getOwner().getLogin(), repository.getName(), repository.getCloneUrl(), null, null, null);
+                            gitMasterDownloader.downloadRepo(tempRepo, masterDownloadFolder, false);
+                            log.info(consoleTag + "[DownloadMaster] Completed downloading master branch of: " + repository.getName());
+                        } catch (Exception e) {
+                            log.error("Error in downloading master branch ZIP for GitHub user account: " + user + " repository: " + repository.getName(), e);
+                        }
+                    });
+                }
+
+                if (!AppConfig.isSkipScan() || AppConfig.isDownloadTags()) {
+                    //Get the list of tags for each repository
+                    userRepositoryList.parallelStream().forEach(repository -> {
+                        log.info(consoleTag + "Fetching tags for GitHub user account: " + user + " repository: " + repository.getName());
+                        try {
+                            List<RepositoryTag> repositoryTagLists = repositoryService.getTags(repository);
+                            log.info(consoleTag + repositoryTagLists.size() + " tags found for user account: " + user + " repository:" + repository.getName());
+
+                            //Create persistable Repo object with repository and tag information
+                            repositoryTagLists.parallelStream().forEach(repositoryTag -> {
+                                Repo repo = new Repo(RepoType.GIT, repository.getOwner().getLogin(), repository.getName(), repository.getCloneUrl(), repositoryTag.getName(), repositoryTag.getZipballUrl(), new Date());
+                                repoList.add(repo);
+
+                                if (AppConfig.isDownloadTags()) {
+                                    try {
+                                        log.info(consoleTag + "[DownloadTags] Started downloading tag: " + repo.getTagName() + " of: " + repository.getName());
+                                        gitTagDownloader.downloadRepo(repo, tagsDownloadFolder, false);
+                                        log.info(consoleTag + "[DownloadTags] Completed downloading tag: " + repo.getTagName() + " of: " + repository.getName());
+                                    } catch (Exception e) {
+                                        log.error("Error in downloading master branch ZIP for GitHub user account: " + user + " repository: " + repository.getName(), e);
+                                    }
+                                }
+                            });
+
+                        } catch (Exception e) {
+                            log.error("Error in fetching tags for GitHub user account: " + user + " repository: " + repository.getName(), e);
+                        }
+                    });
+                } else {
+                    log.warn(consoleTag + "[Skipping] SkipScan parameter is set and tag download is not enabled. Skipping tag information retrieval.");
+                }
+            } catch (Exception e) {
+                log.error("Error in fetching repositories for GitHub user account: " + user, e);
+            }
+        });
+
+        return repoList;
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/repository/RepoInfoGenerator.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/repository/RepoInfoGenerator.java
@@ -1,0 +1,25 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.repository;
+
+import org.wso2.security.tools.reposcanner.entiry.Repo;
+
+import java.util.List;
+
+public interface RepoInfoGenerator {
+    public List<Repo> getRepoList(String consleTag, List<String> users);
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/scanner/GitHubRepoScanner.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/scanner/GitHubRepoScanner.java
@@ -1,0 +1,197 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.scanner;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.apache.log4j.Logger;
+import org.wso2.security.tools.reposcanner.AppConfig;
+import org.wso2.security.tools.reposcanner.artifact.ArtifactInfoGenerator;
+import org.wso2.security.tools.reposcanner.artifact.MavenArtifactInfoGenerator;
+import org.wso2.security.tools.reposcanner.downloader.GitHubTagDownloader;
+import org.wso2.security.tools.reposcanner.downloader.RepoDownloader;
+import org.wso2.security.tools.reposcanner.entiry.Repo;
+import org.wso2.security.tools.reposcanner.entiry.RepoArtifact;
+import org.wso2.security.tools.reposcanner.entiry.RepoError;
+import org.wso2.security.tools.reposcanner.repository.GitHubRepoInfoGenerator;
+import org.wso2.security.tools.reposcanner.repository.RepoInfoGenerator;
+import org.wso2.security.tools.reposcanner.storage.Storage;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+public class GitHubRepoScanner implements RepoScanner {
+    private static Logger log = Logger.getLogger(GitHubRepoScanner.class.getName());
+
+    private char[] oAuth2Token;
+
+    public GitHubRepoScanner(char[] oAuth2Token) {
+        this.oAuth2Token = oAuth2Token;
+    }
+
+    public void scan(Storage storage) throws Exception {
+        String consoleTag = "[GIT] ";
+        log.info(consoleTag + "GIT repository scanning started.");
+
+        //BuildConfigLocator buildConfigLocator = new MavenBuildConfigLocator();
+        ArtifactInfoGenerator mavenArtifactInfoGenerator = new MavenArtifactInfoGenerator();
+        RepoDownloader gitRepoDownloader = new GitHubTagDownloader();
+
+        //Create temp folder for storing downloaded repository content
+        File gitTempFolder = new File("temp-git");
+        if (gitTempFolder.exists()) {
+            FileUtils.deleteDirectory(gitTempFolder);
+        }
+        if (gitTempFolder.mkdir()) {
+            log.info(consoleTag + "Temporary folder created at: " + gitTempFolder.getAbsolutePath());
+        } else {
+            log.error(consoleTag + "Unable to create temporary folder at: " + gitTempFolder.getAbsolutePath());
+            return;
+        }
+
+        //Get list of repositories from GitHub
+        RepoInfoGenerator repoInfoGenerator = new GitHubRepoInfoGenerator(oAuth2Token);
+        List<Repo> repoList = null;
+        if (AppConfig.getGithubAccounts() == null || AppConfig.getGithubAccounts().isEmpty()) {
+            log.error(consoleTag + "No GitHub user accounts provided for the scan. Terminating...");
+            return;
+        } else {
+            repoList = repoInfoGenerator.getRepoList(consoleTag, AppConfig.getGithubAccounts());
+        }
+
+        if (!AppConfig.isSkipScan()) {
+            repoList.parallelStream().forEach(repo -> {
+                String newConsoleTag = consoleTag + "[User:" + repo.getUser() + ",Repo:" + repo.getRepositoryUrl() + ",Tag:" + repo.getTagName() + "] ";
+                try {
+                    if (AppConfig.isRescanRepos() || !storage.isRepoPresent(repo)) {
+
+                        log.info(newConsoleTag + "[Adding] Adding repo to scanning pool");
+
+                        //Create folder to store files from Github
+                        String identifier = repo.getRepositoryName() + "-Tag-" + repo.getTagName();
+                        File artifactTempFolder = new File(gitTempFolder.getAbsoluteFile() + File.separator + identifier);
+                        artifactTempFolder.mkdir();
+                        log.info(consoleTag + "Temporary folder created at: " + artifactTempFolder.getAbsolutePath());
+
+                        try {
+                            //Download from GitHub and extract ZIP
+                            log.info(consoleTag + "Downloading started");
+                            gitRepoDownloader.downloadRepo(repo, artifactTempFolder);
+                            log.info(consoleTag + "Downloading completed");
+
+                            //Locate POM files within the extracted ZIP
+                            log.info(consoleTag + "POM searching started");
+                            Collection<File> sourceFiles = FileUtils.listFiles(artifactTempFolder, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+                            List<File> mavenBuildConfigFiles = sourceFiles.stream().filter(file -> file.getName().equals("pom.xml")).collect(Collectors.toList());
+                            log.info(consoleTag + "POM searching completed");
+
+                            //Execute maven executor plugin on each POM to get Maven ID (groupId, artifactId, packaging, version)
+                            ExecutorService artifactWorkerExecutorService = Executors.newWorkStealingPool();
+
+                            List<Callable<RepoArtifact>> callableArrayList = new ArrayList<>();
+
+                            mavenBuildConfigFiles.parallelStream().forEach(mavenBuildConfigFile -> {
+                                try {
+                                    String path = mavenBuildConfigFile.getAbsolutePath().substring(artifactTempFolder.getAbsolutePath().length(), mavenBuildConfigFile.getAbsolutePath().length());
+                                    path = path.substring(path.indexOf(File.separator, 1), path.length());
+                                    String finalPath = path.replace("pom.xml", "");
+
+                                    String pathIncludedConsoleTag = consoleTag + "[" + path + "] ";
+
+                                    //If this is a repo re-scan, only the artifacts that are not already indexed should be scanned.
+                                    //If thus is not a repo re-scan, repo itself will be skipped if it is already indexed
+                                    boolean scanArtifact = true;
+                                    if (AppConfig.isRescanRepos() && (storage.isArtifactPresent(repo, path) || storage.isErrorPresent(repo, path))) {
+                                        scanArtifact = false;
+                                    }
+                                    if (scanArtifact) {
+                                        log.info(pathIncludedConsoleTag + "[Adding] Adding POM for artifact information gathering pool");
+                                        Callable<RepoArtifact> callable = () -> {
+                                            try {
+                                                RepoArtifact repoArtifactInfo = mavenArtifactInfoGenerator.getArtifact(consoleTag, repo, artifactTempFolder, mavenBuildConfigFile);
+                                                log.info(consoleTag + "Maven ID extracted. Sending for storage.");
+                                                return repoArtifactInfo;
+                                            } catch (Exception e) {
+                                                RepoError repoError = new RepoError(finalPath, "MavenID not found", repo, new Date());
+                                                storage.persistError(repoError);
+
+                                                if (AppConfig.isVerbose()) {
+                                                    log.warn(consoleTag + "[Skipping] Could not extract Maven ID from Maven executor", e);
+                                                } else {
+                                                    log.warn(consoleTag + "[Skipping] Could not extract Maven ID from Maven executor");
+                                                }
+                                                return null;
+                                            }
+                                        };
+                                        callableArrayList.add(callable);
+                                    } else {
+                                        log.warn(pathIncludedConsoleTag + "[Skipping] Artifact is already present in storage.");
+                                    }
+                                } catch (Exception e) {
+                                    log.error(consoleTag + "Exception in extracting artifact information for repository: " + repo + " config file: " + mavenBuildConfigFile.getAbsolutePath(), e);
+                                }
+                            });
+
+                            artifactWorkerExecutorService.invokeAll(callableArrayList).parallelStream().forEach(artifactFuture -> {
+                                RepoArtifact repoArtifact = null;
+                                try {
+                                    repoArtifact = artifactFuture.get();
+                                    if (repoArtifact != null) {
+                                        storage.persist(repoArtifact);
+                                    }
+                                } catch (Exception e) {
+                                    log.error(consoleTag + "Exception in persisting Artifact: " + repoArtifact, e);
+                                }
+                            });
+
+                            //Do cleanup and storage release
+                            log.info(consoleTag + "All threads complete. Clean up tasks started.");
+                            log.info(consoleTag + "Deleting: " + artifactTempFolder.getAbsolutePath());
+                            FileUtils.deleteDirectory(artifactTempFolder);
+                        } catch (Exception e) {
+                            try {
+                                FileUtils.deleteDirectory(artifactTempFolder);
+                            } catch (IOException e1) {
+                                log.warn("Exception in removing temp folder: " + artifactTempFolder.getAbsolutePath());
+                            }
+                            log.error(consoleTag + "Git repository scanning failed: " + identifier, e);
+                        }
+
+                    } else {
+                        log.warn(newConsoleTag + "[Skipping] Repo is already present in storage.");
+                    }
+                } catch (Exception e) {
+                    log.error(consoleTag + "Exception in scanning repository: " + repo, e);
+                }
+            });
+        } else {
+            log.warn(consoleTag + "[Skipping] SkipScan parameter is set.");
+        }
+
+        //Do cleanup and storage release
+        log.info(consoleTag + "All threads complete. Clean up tasks started.");
+        FileUtils.deleteDirectory(gitTempFolder);
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/scanner/RepoScanner.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/scanner/RepoScanner.java
@@ -1,0 +1,23 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.scanner;
+
+import org.wso2.security.tools.reposcanner.storage.Storage;
+
+public interface RepoScanner {
+    public void scan(Storage storage) throws Exception;
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/storage/JDBCStorage.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/storage/JDBCStorage.java
@@ -1,0 +1,201 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.storage;
+
+import org.apache.log4j.Logger;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.wso2.security.tools.reposcanner.AppConfig;
+import org.wso2.security.tools.reposcanner.entiry.Repo;
+import org.wso2.security.tools.reposcanner.entiry.RepoArtifact;
+import org.wso2.security.tools.reposcanner.entiry.RepoError;
+
+import java.util.List;
+import java.util.Properties;
+
+public class JDBCStorage implements Storage {
+    private static Logger log = Logger.getLogger(JDBCStorage.class.getName());
+    private SessionFactory sessionFactory;
+
+    public JDBCStorage(String driverName, String connectionUri, String username, char[] password, String hibernateDialect) {
+        try {
+            Properties properties = new Properties();
+            properties.put("hibernate.connection.driver_class", driverName);
+            properties.put("hibernate.connection.url", connectionUri);
+            properties.put("hibernate.connection.username", username);
+            properties.put("hibernate.connection.password", new String(password));
+            properties.put("hibernate.dialect", hibernateDialect);
+            if (AppConfig.isCreateDB()) {
+                properties.put("hibernate.hbm2ddl.auto", "create");
+            }
+            if (AppConfig.isDebug()) {
+                properties.put("hibernate.show_sql", "true");
+                properties.put("hibernate.format_sql", "true");
+            }
+
+            Configuration configuration = new Configuration();
+            configuration.addProperties(properties);
+
+            configuration.addAnnotatedClass(Repo.class);
+            configuration.addAnnotatedClass(RepoArtifact.class);
+            configuration.addAnnotatedClass(RepoError.class);
+
+            sessionFactory = configuration.buildSessionFactory();
+
+            for (int i = 0; i < password.length; i++) {
+                password[i] = ' ';
+            }
+        } catch (Throwable ex) {
+            log.fatal("Failed to create sessionFactory object. Terminating..." + ex);
+            throw ex;
+        }
+    }
+
+    public synchronized boolean isRepoPresent(Repo repo) throws Exception {
+        return !getRepoInfoList(repo.getUser(), repo.getRepositoryName(), repo.getTagName()).isEmpty();
+    }
+
+    @Override
+    public synchronized boolean isArtifactPresent(Repo repo, String path) throws Exception {
+        if (isRepoPresent(repo)) {
+            List<Repo> repoList = getRepoInfoList(repo.getUser(), repo.getRepositoryName(), repo.getTagName());
+            repo = repoList.get(0);
+
+            Session session = sessionFactory.openSession();
+            List results = null;
+            try {
+                String hql = "FROM org.wso2.security.tools.reposcanner.entiry.RepoArtifact A WHERE A.repo = :repo AND A.path = :path";
+                Query query = session.createQuery(hql);
+                query.setParameter("repo", repo);
+                query.setParameter("path", path);
+                results = query.list();
+                if (results.size() > 1) {
+                    log.warn("[Unexpected] Unexpected condition. Repo Info " + repo.getId() + ", Path \"" + path + "\" found multiple times");
+                }
+            } catch (Exception e) {
+                throw e;
+            } finally {
+                session.close();
+            }
+            return !results.isEmpty();
+        } else {
+            return false;
+        }
+    }
+
+    private synchronized List<Repo> getRepoInfoList(String user, String repositoryName, String tagName) throws Exception {
+        Session session = sessionFactory.openSession();
+        List results = null;
+        try {
+            String hql = "FROM org.wso2.security.tools.reposcanner.entiry.Repo R WHERE R.repositoryName = :repositoryName AND R.tagName = :tagName AND R.user = :user";
+            Query query = session.createQuery(hql);
+            query.setParameter("repositoryName", repositoryName);
+            query.setParameter("tagName", tagName);
+            query.setParameter("user", user);
+            results = query.list();
+            if (results.size() > 1) {
+                log.warn("[Unexpected] Unexpected condition. User: " + user + ", Repo Name:" + repositoryName + ", Tag:" + tagName + " found multiple times");
+            }
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            session.close();
+        }
+        return results;
+    }
+
+    public synchronized boolean persist(RepoArtifact repoArtifactInfo) throws Exception {
+        Session session = sessionFactory.openSession();
+        Transaction transaction = session.beginTransaction();
+
+        try {
+            List<Repo> repoList = getRepoInfoList(repoArtifactInfo.getRepo().getUser(), repoArtifactInfo.getRepo().getRepositoryName(), repoArtifactInfo.getRepo().getTagName());
+            if (repoList.isEmpty()) {
+                session.save(repoArtifactInfo.getRepo());
+            } else {
+                repoArtifactInfo.setRepo(repoList.get(0));
+            }
+            session.save(repoArtifactInfo);
+            transaction.commit();
+        } catch (Exception e) {
+            transaction.rollback();
+            throw e;
+        } finally {
+            session.close();
+        }
+        return true;
+    }
+
+    @Override
+    public synchronized boolean persistError(RepoError repoError) throws Exception {
+        Session session = sessionFactory.openSession();
+        Transaction transaction = session.beginTransaction();
+
+        try {
+            List<Repo> repoList = getRepoInfoList(repoError.getRepo().getUser(), repoError.getRepo().getRepositoryName(), repoError.getRepo().getTagName());
+            if (repoList.isEmpty()) {
+                session.save(repoError.getRepo());
+            } else {
+                repoError.setRepo(repoList.get(0));
+            }
+            session.save(repoError);
+            transaction.commit();
+        } catch (Exception e) {
+            transaction.rollback();
+            throw e;
+        } finally {
+            session.close();
+        }
+
+        return true;
+    }
+
+    public void close() {
+        sessionFactory.close();
+    }
+
+    @Override
+    public boolean isErrorPresent(Repo repo, String path) throws Exception {
+        if (isRepoPresent(repo)) {
+            List<Repo> repoList = getRepoInfoList(repo.getUser(), repo.getRepositoryName(), repo.getTagName());
+            repo = repoList.get(0);
+
+            Session session = sessionFactory.openSession();
+            List results = null;
+            try {
+                String hql = "FROM org.wso2.security.tools.reposcanner.entiry.RepoError A WHERE A.repo = :repo AND A.buildConfigLocation = :path";
+                Query query = session.createQuery(hql);
+                query.setParameter("repo", repo);
+                query.setParameter("path", path);
+                results = query.list();
+                if (results.size() > 1) {
+                    log.warn("[Unexpected] Unexpected condition. Repo Info " + repo.getId() + ", Path \"" + path + "\" found multiple times");
+                }
+            } catch (Exception e) {
+                throw e;
+            } finally {
+                session.close();
+            }
+            return !results.isEmpty();
+        } else {
+            return false;
+        }
+    }
+}

--- a/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/storage/Storage.java
+++ b/repo-scanner/src/main/java/org/wso2/security/tools/reposcanner/storage/Storage.java
@@ -1,0 +1,35 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.security.tools.reposcanner.storage;
+
+import org.wso2.security.tools.reposcanner.entiry.Repo;
+import org.wso2.security.tools.reposcanner.entiry.RepoArtifact;
+import org.wso2.security.tools.reposcanner.entiry.RepoError;
+
+public interface Storage {
+    public boolean isRepoPresent(Repo repo) throws Exception;
+
+    public boolean isArtifactPresent(Repo repo, String path) throws Exception;
+
+    public boolean persist(RepoArtifact repoArtifactInfo) throws Exception;
+
+    public boolean persistError(RepoError repoError) throws Exception;
+
+    public void close();
+
+    public boolean isErrorPresent(Repo repo, String path) throws Exception;
+}

--- a/repo-scanner/src/main/resources/log4j.properties
+++ b/repo-scanner/src/main/resources/log4j.properties
@@ -1,0 +1,20 @@
+# Root logger option
+log4j.rootLogger=INFO, file, stdout
+
+log4j.logger.org.wso2.security.tools.reposcanner=DEBUG
+log4j.logger.org.hibernate=OFF
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=com.jcabi.log.MulticolorLayout
+log4j.appender.stdout.layout.ConversionPattern=%color{%m}%n
+
+# Direct log messages to a log file
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+
+log4j.appender.file.File=RepoScanner.log
+log4j.appender.file.MaxFileSize=10MB
+log4j.appender.file.MaxBackupIndex=500
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
## Purpose
> Currently there is no index or a database of components and component versions that are available in a source repositories. If it was required to find the source code of a given component, it would be required to search through the organization or check with relevant teams on the location of the relevant source files. 

## Goals
> Create a tool that can index and maintain a database of source repositories of WSO2, and create a database of components and component versions that each repository contain.

## Approach
> GitHub scanner that uses the GitHub API will be used to scan through the repositories and identify any maven based components. Maven invoker plugin will be used to gather information about the name of the final artifact, which will be stored along with repository and location information. 

## User stories
> Platform Security Team will frequently use this tool to automatically scan source repositories of WSO2 and maintain a database of components that are available in the source repository. 

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> GitHub API, EGit, jGit, jcommander, maven-invoker