### PR TITLE
OWASP Dependency Check suppression and hint files for WSO2 products

### DIFF
--- a/external/dependency-check-resources/wso2-hints.xml
+++ b/external/dependency-check-resources/wso2-hints.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hints xmlns="https://jeremylong.github.io/DependencyCheck/dependency-hint.1.1.xsd">
+    <hint>
+        <given>
+            <fileName contains="tomcat_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="tomcat" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="com.fasterxml.jackson.core.jackson-core_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="jackson" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="fasterxml" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="jackson-core_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="jackson" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="fasterxml" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="netty-all_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="netty" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="netty_project" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="org.restlet_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="restlet" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="restlet" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="pdfbox_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="pdfbox" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="poi_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="poi" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="apache-zookeeper_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="zookeeper" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="axiom_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="axiom" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="debian" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="axis2_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="axis2" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-beanutils_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_beanutils" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-collections_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_collections" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-fileupload_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_fileupload" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-httpclient_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_httpclient" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-cli_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_cli" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-codec_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_codec" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-collections_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_collections" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-configuration_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_configuration" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-dbcp_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_dbcp" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-io_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_io" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-lang3_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_lang3" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-lang_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_lang" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-pool_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_pool" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="commons-scxml_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_scxml" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="httpclient_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="httpclient" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="wss4j_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="wss4j" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="org.apache.commons.configuration_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_configuration" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="org.apache.commons.lang3_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_lang3" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="org.apache.commons.lang_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_lang" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="org.apache.commons.math3_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="commons_math3" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="opensaml_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="opensaml_java" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="shibboleth" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="openid4java_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="openid4java" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="openid" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="nimbus-jose-jwt_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="nimbus_jose+jwt" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="connect2id" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="groovy-all_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="groovy" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+    <hint>
+        <given>
+            <fileName contains="solr_.*\.jar" regex="true" caseSensitive="true"/>
+        </given>
+        <add>
+            <evidence type="product" source="hint analyzer" name="product" value="solr" confidence="HIGHEST"/>
+            <evidence type="vendor" source="hint analyzer" name="vendor" value="apache" confidence="HIGHEST"/>
+        </add>
+    </hint>
+</hints>

--- a/external/dependency-check-resources/wso2-suppressions.xml
+++ b/external/dependency-check-resources/wso2-suppressions.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+    <suppress>
+        <notes><![CDATA[
+            Eclipse IDE related issues are not relevant to WSO2 Products
+        ]]></notes>
+        <filePath regex="true">.*\.jar</filePath>
+        <cpe>cpe:/a:eclipse:eclipse_ide</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            NTP (Network Time Protocol) daemon related issues are not relevant to WSO2 Products
+        ]]></notes>
+        <filePath regex="true">.*\.jar</filePath>
+        <cpe>cpe:/a:ntp:ntp</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            Issue is not relevant to Axis2 Mail Transport. This issue is applicable only for Axis2 core.
+        ]]></notes>
+        <filePath regex="true">.*\baxis2-transport-mail_.*\.jar</filePath>
+        <cpe>cpe:/a:apache:axis2</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            Issue is not relevant to Geronimo SAAJ library. This issue is applicable only for Geranimo core.
+        ]]></notes>
+        <filePath regex="true">.*\bgeronimo-saaj_1.3_spec_.*\.jar</filePath>
+        <cpe>cpe:/a:apache:geronimo</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            Issue is not relevant to JDBC Pool library. This issue is applicable only for Apache Tomcat.
+        ]]></notes>
+        <filePath regex="true">.*\bjdbc-pool_.*\.jar</filePath>
+        <cpe>cpe:/a:apache:tomcat</cpe>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
## Purpose
> OWASP Dependency Check sometimes identify external dependencies incorrectly (incorrect CPEs). In addition, Dependency Check sometimes identify CVEs that are not relevant to WSO2 products or relevant to the dependencies. 

## Goals
> It is necessary to provide some guidance to OWASP Dependency Check CPE identification engine and CVE matching engine to correct the results.

## Approach
> OWASP Dependency Check allows users to provide suppression XML file, which can be used to suppress invalid CVE identifications. In addition, hints XML file can be used to correct CPE identification.

## User stories
> N/A
## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? no (XML files only)
 - Ran FindSecurityBugs plugin and verified report? no (XML files only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> Suppression and hint file format of OWASP Dependency Check.