### PR TITLE
Adding suppression file modifications made during initial review

### DIFF
--- a/external/dependency-check-resources/wso2-suppressions.xml
+++ b/external/dependency-check-resources/wso2-suppressions.xml
@@ -12,7 +12,7 @@
             Eclipse Business Intelligence and Reporting Tools (BIRT) related issues are not relevant to WSO2 products.
         ]]></notes>
         <filePath regex="true">.*\.jar</filePath>
-        <cve>CVE-2009-4521</cve>
+        <cpe>cpe:/a:eclipse:birt</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
@@ -231,27 +231,12 @@
         <filePath regex="true">.*\bcxf-xjc-ts-.*\.jar</filePath>
         <cpe>cpe:/a:apache:cxf</cpe>
     </suppress>
-    <suppress>
-        <notes><![CDATA[
-           Issue is relevant to Apache CXF core only.
-        ]]></notes>
-        <filePath regex="true">.*\bcxf-bundle-.*\.jar/META-INF/maven/.*\.xml</filePath>
-        <cpe>cpe:/a:apache:cxf</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-            OWASP Dependency Check has only flagged pom.xml file from the dependency. Relevant library is not actually packed into the product
-            as a result of this dependency.  
-        ]]></notes>
-        <filePath regex="true">.*/META-INF/maven/.*\.xml</filePath>
-        <cpe>cpe:/a:.*</cpe>
-    </suppress>
 
     <suppress>
         <notes><![CDATA[
             This is a WSO2 maintained component. Relevant issue has been patched by WSO2 and fixes are available through update channels. 
         ]]></notes>
         <filePath regex="true">.*\borg\.wso2\..*\.jar</filePath>
-        <cpe>cpe:/a:wso2:api_manager</cpe>
+        <cpe>cpe:/a:wso2:.*</cpe>
     </suppress>
 </suppressions>


### PR DESCRIPTION
## Purpose
> OWASP Dependency Check sometimes identify external dependencies incorrectly (incorrect CPEs). In addition, Dependency Check sometimes identify CVEs that are not relevant to WSO2 products or relevant to the dependencies. To address these conditions, suppression information is provided in a XML file. During a review meeting several improvements that can be made to current suppression file was identified. 

## Goals
> It is necessary to introduce some improvement to the existing suppression file to make sure some true positives are retained in the report and to capture additional false positives. 

## Approach
> OWASP Dependency Check suppression file was modified to add new improvements identified. 

## User stories
> N/A
## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? no (XML files only)
 - Ran FindSecurityBugs plugin and verified report? no (XML files only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> Suppression and hint file format of OWASP Dependency Check.