### PR TITLE
Adding security automation scripts

### DIFF
--- a/internal/automation-scripts/BuildDynamicScanEnv.sh
+++ b/internal/automation-scripts/BuildDynamicScanEnv.sh
@@ -1,0 +1,223 @@
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DYNAMIC_HOME="$HOME/env-dynamic"
+PRODUCT_HOME="$HOME/products"
+ADMIN_PASSWORD=$(head -n 1 $HOME/scripts/config/DynamicAdminUser.conf)
+HOST_NAME_APIM=$(head -n 1 $HOME/scripts/config/DynamicHostnameAM.conf)
+HOST_NAME_IS=$(head -n 1 $HOME/scripts/config/DynamicHostnameIS.conf)
+SCRIPT_TAG="[SEC_AUTOMATION_BUILD_DYNAMIC_ENV]"
+
+echo "$SCRIPT_TAG [START]"
+
+echo "$SCRIPT_TAG Existing WSO2 server instances"
+ps -ef | grep java | grep org.wso2.carbon.bootstrap.Bootstrap | tr -s ' ' | cut -d ' ' -f2 | paste -sd "," -
+
+if [[ $(ps -ef | grep java | grep org.wso2.carbon.bootstrap.Bootstrap | tr -s ' ' | cut -d ' ' -f2) ]]; then
+
+	echo "$SCRIPT_TAG Killing existing WSO2 server instances"
+	kill -9 $(ps -ef | grep java | grep org.wso2.carbon.bootstrap.Bootstrap | tr -s ' ' | cut -d ' ' -f2)
+
+	echo "$SCRIPT_TAG Existing WSO2 server instances after killing"
+	ps -ef | grep java | grep org.wso2.carbon.bootstrap.Bootstrap | tr -s ' ' | cut -d ' ' -f2 | paste -sd "," -
+
+fi
+
+echo "$SCRIPT_TAG Cleaning dynamic environment home: $DYNAMIC_HOME"
+rm -rf $DYNAMIC_HOME
+
+echo "$SCRIPT_TAG Calling WUM update process"
+bash $HOME/scripts/UpdateProducts.sh
+
+cp -R $PRODUCT_HOME $DYNAMIC_HOME
+echo "$SCRIPT_TAG Copied $PRODUCT_HOME to $DYNAMIC_HOME"
+
+for product in $(cat $HOME/scripts/config/SupportedProductList.conf)
+do
+
+	CARBON_XML_PATH=$(find $DYNAMIC_HOME/$product | grep "carbon.xml")
+	echo "$SCRIPT_TAG carbon.xml path $CARBON_XML_PATH"
+
+	USERMGT_XML_PATH=$(find $DYNAMIC_HOME/$product | grep "user-mgt.xml")
+	echo "$SCRIPT_TAG user-mgt.xml path $USERMGT_XML_PATH"
+
+	CATALINA_XML_PATH=$(find $DYNAMIC_HOME/$product | grep "catalina-server.xml")
+	echo "$SCRIPT_TAG catalina-server.xml path $CATALINA_XML_PATH"
+
+	if [[ $product == *"wso2am"* ]]; then
+
+		OFFSET=0
+		echo "$SCRIPT_TAG Configuration API Manager - Offset is: $OFFSET"
+
+		#Proxy Configuration
+		echo "$SCRIPT_TAG Configuration API Manager - Proxy Configuration"
+		sed -i -e "s/<.*HostName>.*<\/HostName.*>/<HostName>$HOST_NAME_APIM<\/HostName>/g" $CARBON_XML_PATH
+		sed -i -e "s/<.*MgtHostName>.*<\/MgtHostName.*>/<MgtHostName>$HOST_NAME_APIM<\/MgtHostName>/g" $CARBON_XML_PATH
+		sed -i -e "s/port=\"9443\"/port=\"9443\" proxyPort=\"443\"/g" $CATALINA_XML_PATH
+		sed -i -e "s/port=\"9763\"/port=\"9763\" proxyPort=\"80\"/g" $CATALINA_XML_PATH
+
+		#Carbon Authenticator Configuration
+		echo "$SCRIPT_TAG Configuration API Manager - SSO for Management Console"
+		AUTHENTICATOR_XML=$(find $DYNAMIC_HOME/$product | grep "authenticators.xml")
+		sed -i -e "s/Authenticator name=\"SAML2SSOAuthenticator\" disabled=\"true\"/Authenticator name=\"SAML2SSOAuthenticator\" disabled=\"false\"/g" $AUTHENTICATOR_XML
+		sed -i -e "s/https:\/\/localhost:9443\/samlsso/https:\/\/$HOST_NAME_APIM:443\/samlsso/g" $AUTHENTICATOR_XML
+		sed -i -e "s/https:\/\/localhost:9443\/acs/https:\/\/$HOST_NAME_APIM:443\/acs/g" $AUTHENTICATOR_XML
+
+		#Publisher Configuration
+		echo "$SCRIPT_TAG Configuration API Manager - SSO for Publisher"
+		SITE_CONF="$DYNAMIC_HOME/$product/repository/deployment/server/jaggeryapps/publisher/site/conf/site.json"
+		sed -i "0,/\"enabled\".*:.*false.*,/s//\"enabled\" : \"true\",/" $SITE_CONF
+		sed -i -e "s/https:\/\/localhost:9443\/samlsso/https:\/\/$HOST_NAME_APIM:443\/samlsso/g" $SITE_CONF
+		tac $SITE_CONF > $SITE_CONF-tmp
+		sed -i "0,/\"enabled\".*:.*false.*,/s//\"enabled\" : \"true\",\/\//" $SITE_CONF-tmp
+		tac $SITE_CONF-tmp > $SITE_CONF
+		rm  $SITE_CONF-tmp
+		sed -i -e "s/sample.proxydomain.com/$HOST_NAME_APIM/g" $SITE_CONF
+		sed -i -e "s/\"context\".*:.*\"\"/\"context\":\"\/publisher\"/g" $SITE_CONF
+
+		#Store Configuration
+		echo "$SCRIPT_TAG Configuration API Manager - SSO for Store"
+		SITE_CONF="$DYNAMIC_HOME/$product/repository/deployment/server/jaggeryapps/store/site/conf/site.json"
+		sed -i "0,/\"enabled\".*:.*false.*,/s//\"enabled\" : \"true\",/" $SITE_CONF
+		sed -i -e "s/https:\/\/localhost:9443\/samlsso/https:\/\/$HOST_NAME_APIM:443\/samlsso/g" $SITE_CONF
+		tac $SITE_CONF > $SITE_CONF-tmp
+		sed -i "0,/\"enabled\".*:.*false.*,/s//\"enabled\" : \"true\",\/\//" $SITE_CONF-tmp
+		tac $SITE_CONF-tmp > $SITE_CONF
+		rm  $SITE_CONF-tmp
+		sed -i -e "s/sample.proxydomain.com/$HOST_NAME_APIM/g" $SITE_CONF
+		sed -i -e "s/\"context\".*:.*\"\"/\"context\":\"\/store\"/g" $SITE_CONF
+
+		#Admin Configuration (Admin application does not support SSO. Hence comenting this for now)
+		#echo "$SCRIPT_TAG Configuration API Manager - SSO for Admin"
+		#SITE_CONF="$DYNAMIC_HOME/$product/repository/deployment/server/jaggeryapps/admin/site/conf/site.json"
+		#sed -i "0,/\"enabled\".*:.*false.*,/s//\"enabled\" : \"true\",/" $SITE_CONF
+		#sed -i -e "s/https:\/\/localhost:9443\/samlsso/https:\/\/$HOST_NAME_APIM:443\/samlsso/g" $SITE_CONF
+		#tac $SITE_CONF > $SITE_CONF-tmp
+		#sed -i "0,/\"enabled\".*:.*false.*,/s//\"enabled\" : \"true\",\/\//" $SITE_CONF-tmp
+		#tac $SITE_CONF-tmp > $SITE_CONF
+		#rm  $SITE_CONF-tmp
+		#sed -i -e "s/sample.proxydomain.com/$HOST_NAME_APIM/g" $SITE_CONF
+		#sed -i -e "s/\"context\".*:.*\"\"/\"context\":\"\/admin\"/g" $SITE_CONF
+
+	elif [[ $product == *"wso2is"* ]]; then
+
+		if [[ $product == "wso2is"* ]]; then
+
+			echo "$SCRIPT_TAG Configuration API Manager - SSO IDP in: $DYNAMIC_HOME/$product-AM-SSO"
+			cp -R $DYNAMIC_HOME/$product $DYNAMIC_HOME/$product-AM-SSO
+
+			CARBON_XML_PATH_IS_AM=$(find $DYNAMIC_HOME/$product-AM-SSO | grep "carbon.xml")
+			echo "$SCRIPT_TAG carbon.xml path $CARBON_XML_PATH_IS_AM"
+
+			USERMGT_XML_PATH_IS_AM=$(find $DYNAMIC_HOME/$product-AM-SSO | grep "user-mgt.xml")
+			echo "$SCRIPT_TAG user-mgt.xml path $USERMGT_XML_PATH_IS_AM"
+
+			CATALINA_XML_PATH_IS_AM=$(find $DYNAMIC_HOME/$product-AM-SSO | grep "catalina-server.xml")
+			echo "$SCRIPT_TAG catalina-server.xml path $CATALINA_XML_PATH_IS_AM"
+
+			echo "$SCRIPT_TAG Configuration API Manager - SSO IDP - Proxy Configuration"
+			sed -i -e "s/<.*HostName>.*<\/HostName.*>/<HostName>$HOST_NAME_APIM<\/HostName>/g" $CARBON_XML_PATH_IS_AM
+			sed -i -e "s/<.*MgtHostName>.*<\/MgtHostName.*>/<MgtHostName>$HOST_NAME_APIM<\/MgtHostName>/g" $CARBON_XML_PATH_IS_AM
+			sed -i -e "s/port=\"9443\"/port=\"9443\" proxyPort=\"443\"/g" $CATALINA_XML_PATH_IS_AM
+			sed -i -e "s/port=\"9763\"/port=\"9763\" proxyPort=\"80\"/g" $CATALINA_XML_PATH_IS_AM
+
+			echo "$SCRIPT_TAG Configuration API Manager - SSO IDP - Offset Configuration (Offset is set to 100)"
+			sed -i -e "s/<Offset>0<\/Offset>/<Offset>100<\/Offset>/g" $CARBON_XML_PATH_IS_AM
+
+			echo "$SCRIPT_TAG Configuration API Manager - SSO IDP - Password and Compression Configuration"
+			sed -i -e "s/<Password>admin<\/Password>/<Password>$ADMIN_PASSWORD<\/Password>/g" $USERMGT_XML_PATH_IS_AM
+			sed -i -e "s/compression=\"on\"/compression=\"off\"/g" $CATALINA_XML_PATH_IS_AM
+
+			sed -i -e "s/<UserStoreManager class=\"org.wso2.carbon.user.core.ldap.ReadWriteLDAPUserStoreManager\">/<!--UserStoreManager class=\"org.wso2.carbon.user.core.ldap.ReadWriteLDAPUserStoreManager\">/g" $USERMGT_XML_PATH_IS_AM
+			tac $USERMGT_XML_PATH_IS_AM > $USERMGT_XML_PATH_IS_AM-tmp
+			sed -i "0,/<\/UserStoreManager>/s//<\/UserStoreManager-->/" $USERMGT_XML_PATH_IS_AM-tmp
+			tac $USERMGT_XML_PATH_IS_AM-tmp > $USERMGT_XML_PATH_IS_AM
+			rm  $USERMGT_XML_PATH_IS_AM-tmp
+			sed -i -e "s/<!--UserStoreManager class=\"org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager\">/<UserStoreManager class=\"org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager\">/g" $USERMGT_XML_PATH_IS_AM
+			sed -i "0,/<\/UserStoreManager-->/s//<\/UserStoreManager>/" $USERMGT_XML_PATH_IS_AM
+
+			echo "$SCRIPT_TAG Configuration API Manager - SSO IDP - Copying file based service providers"
+			cp $HOME/scripts/am-sso-config/am-sp-*.xml $DYNAMIC_HOME/$product-AM-SSO/repository/conf/identity/service-providers
+
+			echo "$SCRIPT_TAG Configuration API Manager - SSO IDP - Copying sso-idp-config"
+			cp -rf $HOME/scripts/am-sso-config/am-sso-idp-config.xml $DYNAMIC_HOME/$product-AM-SSO/repository/conf/identity/sso-idp-config.xml
+
+			echo "$SCRIPT_TAG Configuration API Manager - SSO IDP - Updating sso-idp-config with hostname"
+			sed -i -e "s/localhost:9443/$HOST_NAME_APIM/g" $DYNAMIC_HOME/$product-AM-SSO/repository/conf/identity/sso-idp-config.xml
+
+			echo "$SCRIPT_TAG Configuration API Manager - SSO IDP - Importing Certs"
+			keytool -import -trustcacerts -alias is -file /etc/nginx/ssl/nginx-is.crt -keystore $DYNAMIC_HOME/$product-AM-SSO/repository/resources/security/client-truststore.jks -storepass wso2carbon -noprompt
+			keytool -import -trustcacerts -alias apim -file /etc/nginx/ssl/nginx.crt -keystore $DYNAMIC_HOME/$product-AM-SSO/repository/resources/security/client-truststore.jks -storepass wso2carbon -noprompt
+
+			CARBON_START_SCRIPT_PATH=$(find $DYNAMIC_HOME/$product-AM-SSO | grep "wso2server.sh")
+			echo "$SCRIPT_TAG Starting WSO2 Server at $CARBON_START_SCRIPT_PATH"
+			nohup bash $CARBON_START_SCRIPT_PATH >/dev/null 2>&1 &
+		else
+			echo "$SCRIPT_TAG [ERROR] Unknown product, skipping configuration"
+			rm -rf $DYNAMIC_HOME/$product
+			continue
+			echo "$SCRIPT_TAG [ERROR] THIS SHOULD NOT PRINT"
+		fi
+
+		OFFSET=1
+
+		echo "$SCRIPT_TAG Configuration Identity Server - Offset is: $OFFSET"
+
+		echo "$SCRIPT_TAG Configuration Identity Server - Proxy Configuration"
+		sed -i -e "s/<.*HostName>.*<\/HostName.*>/<HostName>$HOST_NAME_IS<\/HostName>/g" $CARBON_XML_PATH
+		sed -i -e "s/<.*MgtHostName>.*<\/MgtHostName.*>/<MgtHostName>$HOST_NAME_IS<\/MgtHostName>/g" $CARBON_XML_PATH
+		sed -i -e "s/port=\"9443\"/port=\"9443\" proxyPort=\"443\"/g" $CATALINA_XML_PATH
+		sed -i -e "s/port=\"9763\"/port=\"9763\" proxyPort=\"80\"/g" $CATALINA_XML_PATH
+
+		sed -i -e "s/<UserStoreManager class=\"org.wso2.carbon.user.core.ldap.ReadWriteLDAPUserStoreManager\">/<!--UserStoreManager class=\"org.wso2.carbon.user.core.ldap.ReadWriteLDAPUserStoreManager\">/g" $USERMGT_XML_PATH
+		tac $USERMGT_XML_PATH > $USERMGT_XML_PATH-tmp
+		sed -i "0,/<\/UserStoreManager>/s//<\/UserStoreManager-->/" $USERMGT_XML_PATH-tmp
+		tac $USERMGT_XML_PATH-tmp > $USERMGT_XML_PATH
+		rm  $USERMGT_XML_PATH-tmp
+		sed -i -e "s/<!--UserStoreManager class=\"org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager\">/<UserStoreManager class=\"org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager\">/g" $USERMGT_XML_PATH
+		sed -i "0,/<\/UserStoreManager-->/s//<\/UserStoreManager>/" $USERMGT_XML_PATH
+
+		#Carbon Authenticator Configuration
+		echo "$SCRIPT_TAG Configuration IS - SSO for Management Console"
+		AUTHENTICATOR_XML=$(find $DYNAMIC_HOME/$product | grep "authenticators.xml")
+		sed -i -e "s/Authenticator name=\"SAML2SSOAuthenticator\" disabled=\"true\"/Authenticator name=\"SAML2SSOAuthenticator\" disabled=\"false\"/g" $AUTHENTICATOR_XML
+		sed -i -e "s/https:\/\/localhost:9443\/samlsso/https:\/\/$HOST_NAME_IS:443\/samlsso/g" $AUTHENTICATOR_XML
+		sed -i -e "s/https:\/\/localhost:9443\/acs/https:\/\/$HOST_NAME_IS:443\/acs/g" $AUTHENTICATOR_XML
+
+		echo "$SCRIPT_TAG Configuration IS - SSO - Copying file based service providers"
+		cp $HOME/scripts/is-sso-config/is-sp-*.xml $DYNAMIC_HOME/$product/repository/conf/identity/service-providers
+
+		echo "$SCRIPT_TAG Configuration IS - SSO - Copying sso-idp-config"
+		cp -rf $HOME/scripts/is-sso-config/is-sso-idp-config.xml $DYNAMIC_HOME/$product/repository/conf/identity/sso-idp-config.xml
+
+		echo "$SCRIPT_TAG Configuration IS - SSO - Updating sso-idp-config with hostname"
+		sed -i -e "s/localhost:9443/$HOST_NAME_IS/g" $DYNAMIC_HOME/$product/repository/conf/identity/sso-idp-config.xml
+	fi
+
+	echo "$SCRIPT_TAG Configuration WSO2 Server - Importing Certs"
+	keytool -import -trustcacerts -alias is -file /etc/nginx/ssl/nginx-is.crt -keystore $DYNAMIC_HOME/$product/repository/resources/security/client-truststore.jks -storepass wso2carbon -noprompt
+	keytool -import -trustcacerts -alias apim -file /etc/nginx/ssl/nginx.crt -keystore $DYNAMIC_HOME/$product/repository/resources/security/client-truststore.jks -storepass wso2carbon -noprompt
+
+	echo "$SCRIPT_TAG Configuration WSO2 Server - Offset, Password and Compression Configuration"
+	sed -i -e "s/<Offset>0<\/Offset>/<Offset>$OFFSET<\/Offset>/g" $CARBON_XML_PATH
+	sed -i -e "s/<Password>admin<\/Password>/<Password>$ADMIN_PASSWORD<\/Password>/g" $USERMGT_XML_PATH
+	sed -i -e "s/compression=\"on\"/compression=\"off\"/g" $CATALINA_XML_PATH
+
+	CARBON_START_SCRIPT_PATH=$(find $DYNAMIC_HOME/$product | grep "wso2server.sh")
+	echo "$SCRIPT_TAG Starting WSO2 Server at $CARBON_START_SCRIPT_PATH"
+	nohup bash $CARBON_START_SCRIPT_PATH >/dev/null 2>&1 &
+
+done
+
+echo "$SCRIPT_TAG [END]"

--- a/internal/automation-scripts/BuildDynamicScanEnv.sh
+++ b/internal/automation-scripts/BuildDynamicScanEnv.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/automation-scripts/BuildStaticScanZip.sh
+++ b/internal/automation-scripts/BuildStaticScanZip.sh
@@ -1,0 +1,91 @@
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+STATIC_HOME="$HOME/env-static"
+PRODUCT_HOME="$HOME/products"
+SCRIPT_TAG="[SEC_AUTOMATION_BUILD_STSTIC_ZIP]"
+
+echo "$SCRIPT_TAG [START]"
+
+echo "$SCRIPT_TAG Calling WUM update process"
+bash $HOME/scripts/UpdateProducts.sh
+
+echo "$SCRIPT_TAG Cleaning static environment home: $STATIC_HOME"
+rm -rf $STATIC_HOME
+
+cp -R $PRODUCT_HOME $STATIC_HOME
+echo "$SCRIPT_TAG Copied $PRODUCT_HOME to $STATIC_HOME"
+
+for product in $(cat $HOME/scripts/config/SupportedProductList.conf)
+do
+		echo "$SCRIPT_TAG Moving product to work folder: $STATIC_HOME/$product-work"
+		mkdir $STATIC_HOME/$product-work
+
+		for pattern in $(cat $HOME/scripts/config/StaticScanIncludeFileNamePatterns.conf)
+		do
+			echo "$SCRIPT_TAG Processing pattern: $pattern"
+			if [[ $pattern == "regex/"* ]]; then
+				actual_pattern=$(echo "$pattern" | cut -d'/' -f 2)
+				echo "$SCRIPT_TAG Copying files that match the pattern: $actual_pattern"
+				find $STATIC_HOME/$product -regex $actual_pattern -exec cp {} $STATIC_HOME/$product-work \;
+			else
+				echo "$SCRIPT_TAG Copying files that match the pattern: $pattern"
+				find $STATIC_HOME/$product -name $pattern -exec cp {} $STATIC_HOME/$product-work \;
+			fi
+		done
+
+		for filename in $(cat $HOME/scripts/config/StaticScanExcludeFileNames.conf)
+		do
+			echo "$SCRIPT_TAG Excluding $STATIC_HOME/$product-work/$filename"
+			rm $STATIC_HOME/$product-work/$filename
+		done
+
+		echo "$SCRIPT_TAG Removing product folder: $STATIC_HOME/$product"
+		rm -rf $STATIC_HOME/$product
+
+		echo "$SCRIPT_TAG Creating the ZIP of scan artifacts"
+		cd $STATIC_HOME
+		zip -j -r -9 -q $product-scan.zip $product-work
+		cd -
+
+		echo "$SCRIPT_TAG Removing the ZIP source: $STATIC_HOME/$product-work"
+		rm -rf $STATIC_HOME/$product-work
+
+		echo "$SCRIPT_TAG Proceed with uploading: $STATIC_HOME/$product-scan.zip"
+
+		VERACODE_APP_ID=-1
+		if [[ $product == *"wso2am"* ]]; then
+			VERACODE_APP_ID=328371
+		elif [[ $product == *"wso2is"* ]]; then
+			VERACODE_APP_ID=328089
+		elif [[ $product == *"wso2iot"* ]]; then
+			VERACODE_APP_ID=217912 #is master
+		elif [[ $product == *"wso2das"* ]]; then
+			VERACODE_APP_ID=218676 #carbon
+		elif [[ $product == *"wso2ei"* ]]; then
+			VERACODE_APP_ID=328373
+		else
+			echo "$SCRIPT_TAG [ERROR] Unknown product, skipping configuration"
+			rm -rf $STATIC_HOME/$product
+			continue
+			echo "$SCRIPT_TAG [ERROR] THIS SHOULD NOT PRINT"
+		fi
+
+		if [[ $VERACODE_APP_ID > -1 ]]; then
+			echo "$SCRIPT_TAG Submitting veracode scan for $STATIC_HOME/$product-scan.zip with app ID: $VERACODE_APP_ID."
+			curl -q --progress-bar --compressed -u $(cat $HOME/scripts/config/VeracodeLogin.conf) https://analysiscenter.veracode.com/api/5.0/uploadfile.do -F "app_id=$VERACODE_APP_ID" -F "file=@$STATIC_HOME/$product-scan.zip"
+			curl -q --progress-bar --compressed -u $(cat $HOME/scripts/config/VeracodeLogin.conf) https://analysiscenter.veracode.com/api/5.0/beginprescan.do -F "app_id=$VERACODE_APP_ID" -F "auto_scan=true"
+		fi
+done
+
+echo "$SCRIPT_TAG [END]"

--- a/internal/automation-scripts/BuildStaticScanZip.sh
+++ b/internal/automation-scripts/BuildStaticScanZip.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/automation-scripts/RunDependencyCheck.sh
+++ b/internal/automation-scripts/RunDependencyCheck.sh
@@ -1,0 +1,86 @@
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DEPENDENCY_HOME="$HOME/env-dependency-check"
+PRODUCT_HOME="$HOME/products"
+LOG_HOME="$HOME/outputs"
+OUTPUT_HOME="$HOME/outputs"
+TOOL_SCRIPT="$HOME/tools/dependency-check-3.0.1/bin/dependency-check.sh"
+SCRIPT_TAG="[SEC_AUTOMATION_DEPENDENCY_CHECK]"
+
+DEBUG=true
+
+echo "$SCRIPT_TAG [START]"
+
+# Downloading exclusion and hint files
+rm -rf $HOME/tools/dependency-check-resources
+echo "$SCRIPT_TAG Downloading hints.xml from security-tools repo"
+wget -q --show-progress https://raw.githubusercontent.com/wso2/security-tools/master/external/dependency-check-resources/wso2-hints.xml -P ~/tools/dependency-check-resources
+echo "$SCRIPT_TAG Downloading suppressions.xml from security-tools repo"
+wget -q --show-progress https://raw.githubusercontent.com/wso2/security-tools/master/external/dependency-check-resources/wso2-suppressions.xml -P ~/tools/dependency-check-resources
+
+echo "$SCRIPT_TAG Cleaning Dependency Check environment home: $DEPENDENCY_HOME"
+rm -rf $DEPENDENCY_HOME
+
+echo "$SCRIPT_TAG Calling WUM update process"
+bash $HOME/scripts/UpdateProducts.sh
+
+cp -R $PRODUCT_HOME $DEPENDENCY_HOME
+echo "$SCRIPT_TAG Copied $PRODUCT_HOME/$product to $DEPENDENCY_HOME"
+
+timestamp=$(date -d "today" +"%Y-%m-%d-%H.%M.%S")
+for product in $(ls -l $DEPENDENCY_HOME | tr -s ' ' | cut -d ' ' -f9 |  grep -v -e '^$'); do
+	date=$(date -d "today" +"%Y-%m-%d")
+	if [ ! -d "$OUTPUT_HOME/$date" ]; then
+		mkdir -p $OUTPUT_HOME/$date
+		echo "$SCRIPT_TAG Created $OUTPUT_HOME/$date"
+	fi
+	if [ ! -d "mkdir $OUTPUT_HOME/$date/$product-$timestamp" ]; then
+		mkdir -p $OUTPUT_HOME/$date/$product-$timestamp
+		echo "$SCRIPT_TAG Created $LOG_HOME/$date/$product-$timestamp"
+	fi
+
+	if [ ! -d "mkdir $LOG_HOME/$date" ]; then
+		mkdir -p $LOG_HOME/$date
+		echo "$SCRIPT_TAG Created $LOG_HOME/$date"
+	fi
+
+	echo "$SCRIPT_TAG Starting Dependency Check for: $PRODUCT_HOME/$product"
+
+	if [[ DEBUG == true ]]; then
+		read -r -d '' TOOL_ARG <<- EOM
+		-l $LOG_HOME/$date/$product-dependency-check-$timestamp.log
+		-o $OUTPUT_HOME/$date/$product-$timestamp
+		--project $product
+		-s $PRODUCT_HOME/$product
+		--suppression $HOME/tools/dependency-check-resources/wso2-suppressions.xml
+		--hints $HOME/tools/dependency-check-resources/wso2-hints.xml
+		-f ALL
+		EOM
+	else
+		read -r -d '' TOOL_ARG <<- EOM
+		-o $OUTPUT_HOME/$date/$product-$timestamp
+		--project $product
+		-s $PRODUCT_HOME/$product
+		--suppression $HOME/tools/dependency-check-resources/wso2-suppressions.xml
+		--hints $HOME/tools/dependency-check-resources/wso2-hints.xml
+		-f ALL
+		EOM
+	fi
+
+	$TOOL_SCRIPT $TOOL_ARG
+	echo "$SCRIPT_TAG Ending Dependency Check for: $PRODUCT_HOME/$product"
+done
+
+echo "$SCRIPT_TAG [END]"

--- a/internal/automation-scripts/RunDependencyCheck.sh
+++ b/internal/automation-scripts/RunDependencyCheck.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/automation-scripts/UpdateProducts.sh
+++ b/internal/automation-scripts/UpdateProducts.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/automation-scripts/UpdateProducts.sh
+++ b/internal/automation-scripts/UpdateProducts.sh
@@ -1,0 +1,48 @@
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PRODUCT_HOME="$HOME/products"
+SCRIPT_TAG="[SEC_AUTOMATION_UPDATE_PRODUCTS]"
+
+echo "$SCRIPT_TAG [START]"
+
+echo "$SCRIPT_TAG Cleaning product home: ($PRODUCT_HOME)"
+rm -rf $PRODUCT_HOME
+mkdir $PRODUCT_HOME
+
+for product in $(cat $HOME/scripts/config/SupportedProductList.conf)
+do
+	echo "$SCRIPT_TAG Adding $product to WUM"
+	wum add -yv $product
+done
+
+echo "$SCRIPT_TAG Starting WUM update process"
+wum update -v
+
+for product in $(cat $HOME/scripts/config/SupportedProductList.conf)
+do
+	IFS='-' read -r -a namesplits <<< "$product"
+
+	echo "$SCRIPT_TAG Listing versions of $product available in WUM directory"
+	ls -ltr $HOME/.wum-wso2/products/${namesplits[0]}/${namesplits[1]} | tr -s ' ' | cut -d ' ' -f9 | grep -v -e '^$' | paste -sd "," -
+
+	echo "$SCRIPT_TAG Latest version of $product available in WUM directory"
+	ls -ltr $HOME/.wum-wso2/products/${namesplits[0]}/${namesplits[1]} | tr -s ' ' | cut -d ' ' -f9 | grep -v -e '^$' | tail -1
+
+	latestZip=$(ls -ltr $HOME/.wum-wso2/products/${namesplits[0]}/${namesplits[1]} | tr -s ' ' | cut -d ' ' -f9 | grep -v -e '^$' | tail -1)
+	unzip -q $HOME/.wum-wso2/products/${namesplits[0]}/${namesplits[1]}/$latestZip -d $PRODUCT_HOME
+	echo "$SCRIPT_TAG Extracted ${namesplits[0]}/${namesplits[1]}/$latestZip to $PRODUCT_HOME"
+done
+
+echo "$SCRIPT_TAG [END]"

--- a/internal/automation-scripts/am-sso-config/am-sp-admin.xml
+++ b/internal/automation-scripts/am-sso-config/am-sp-admin.xml
@@ -1,0 +1,39 @@
+<ServiceProvider>
+    <ApplicationID>7</ApplicationID>
+    <ApplicationName>am-admin</ApplicationName>
+    <Description>APIM Publisher Service Provider</Description>
+    <IsSaaSApp>true</IsSaaSApp>
+    <InboundAuthenticationConfig>
+        <InboundAuthenticationRequestConfigs>
+            <InboundAuthenticationRequestConfig>
+                <InboundAuthKey>API_WORKFLOW_ADMIN</InboundAuthKey>
+                <InboundAuthType>samlsso</InboundAuthType>
+                <Properties></Properties>
+            </InboundAuthenticationRequestConfig>
+        </InboundAuthenticationRequestConfigs>
+    </InboundAuthenticationConfig>
+
+    <LocalAndOutBoundAuthenticationConfig>
+    <AuthenticationSteps>
+        <AuthenticationStep>
+            <StepOrder>1</StepOrder>
+            <LocalAuthenticatorConfigs>
+                <LocalAuthenticatorConfig>
+                    <Name>BasicAuthenticator</Name>
+                    <DisplayName>basicauth</DisplayName>
+                    <IsEnabled>true</IsEnabled>
+                </LocalAuthenticatorConfig>
+            </LocalAuthenticatorConfigs>>
+            <SubjectStep>true</SubjectStep>
+            <AttributeStep>true</AttributeStep>
+        </AuthenticationStep>
+    </AuthenticationSteps>
+</LocalAndOutBoundAuthenticationConfig>
+    <RequestPathAuthenticatorConfigs></RequestPathAuthenticatorConfigs>
+    <InboundProvisioningConfig></InboundProvisioningConfig>
+    <OutboundProvisioningConfig></OutboundProvisioningConfig>
+    <ClaimConfig>
+        <AlwaysSendMappedLocalSubjectId>true</AlwaysSendMappedLocalSubjectId>
+        <LocalClaimDialect>true</LocalClaimDialect><ClaimMappings><ClaimMapping><LocalClaim><ClaimUri>http://wso2.org/claims/givenname</ClaimUri></LocalClaim><RemoteClaim><ClaimUri>http://wso2.org/claims/givenName</ClaimUri>ClaimUri></RemoteClaim><RequestClaim>true</RequestClaim></ClaimMapping></ClaimMappings></ClaimConfig>
+    <PermissionAndRoleConfig></PermissionAndRoleConfig>
+</ServiceProvider>

--- a/internal/automation-scripts/am-sso-config/am-sp-carbon.xml
+++ b/internal/automation-scripts/am-sso-config/am-sp-carbon.xml
@@ -1,0 +1,39 @@
+<ServiceProvider>
+    <ApplicationID>4</ApplicationID>
+    <ApplicationName>am-carbon</ApplicationName>
+    <Description>APIM Carbon Service Provider</Description>
+    <IsSaaSApp>true</IsSaaSApp>
+    <InboundAuthenticationConfig>
+        <InboundAuthenticationRequestConfigs>
+            <InboundAuthenticationRequestConfig>
+                <InboundAuthKey>carbonServer</InboundAuthKey>
+                <InboundAuthType>samlsso</InboundAuthType>
+                <Properties></Properties>
+            </InboundAuthenticationRequestConfig>
+        </InboundAuthenticationRequestConfigs>
+    </InboundAuthenticationConfig>
+   
+    <LocalAndOutBoundAuthenticationConfig>
+    <AuthenticationSteps>
+        <AuthenticationStep>
+            <StepOrder>1</StepOrder>
+            <LocalAuthenticatorConfigs>
+                <LocalAuthenticatorConfig>
+                    <Name>BasicAuthenticator</Name>
+                    <DisplayName>basicauth</DisplayName>
+                    <IsEnabled>true</IsEnabled>
+                </LocalAuthenticatorConfig>
+            </LocalAuthenticatorConfigs>>
+            <SubjectStep>true</SubjectStep>
+            <AttributeStep>true</AttributeStep>
+        </AuthenticationStep>
+    </AuthenticationSteps>
+</LocalAndOutBoundAuthenticationConfig>
+    <RequestPathAuthenticatorConfigs></RequestPathAuthenticatorConfigs>
+    <InboundProvisioningConfig></InboundProvisioningConfig>
+    <OutboundProvisioningConfig></OutboundProvisioningConfig>
+    <ClaimConfig>
+        <AlwaysSendMappedLocalSubjectId>true</AlwaysSendMappedLocalSubjectId>
+        <LocalClaimDialect>true</LocalClaimDialect><ClaimMappings><ClaimMapping><LocalClaim><ClaimUri>http://wso2.org/claims/givenname</ClaimUri></LocalClaim><RemoteClaim><ClaimUri>http://wso2.org/claims/givenName</ClaimUri>ClaimUri></RemoteClaim><RequestClaim>true</RequestClaim></ClaimMapping></ClaimMappings></ClaimConfig>   
+    <PermissionAndRoleConfig></PermissionAndRoleConfig>
+</ServiceProvider>

--- a/internal/automation-scripts/am-sso-config/am-sp-publisher.xml
+++ b/internal/automation-scripts/am-sso-config/am-sp-publisher.xml
@@ -1,0 +1,39 @@
+<ServiceProvider>
+    <ApplicationID>5</ApplicationID>
+    <ApplicationName>am-publisher</ApplicationName>
+    <Description>APIM Publisher Service Provider</Description>
+    <IsSaaSApp>true</IsSaaSApp>
+    <InboundAuthenticationConfig>
+        <InboundAuthenticationRequestConfigs>
+            <InboundAuthenticationRequestConfig>
+                <InboundAuthKey>API_PUBLISHER</InboundAuthKey>
+                <InboundAuthType>samlsso</InboundAuthType>
+                <Properties></Properties>
+            </InboundAuthenticationRequestConfig>
+        </InboundAuthenticationRequestConfigs>
+    </InboundAuthenticationConfig>
+   
+    <LocalAndOutBoundAuthenticationConfig>
+    <AuthenticationSteps>
+        <AuthenticationStep>
+            <StepOrder>1</StepOrder>
+            <LocalAuthenticatorConfigs>
+                <LocalAuthenticatorConfig>
+                    <Name>BasicAuthenticator</Name>
+                    <DisplayName>basicauth</DisplayName>
+                    <IsEnabled>true</IsEnabled>
+                </LocalAuthenticatorConfig>
+            </LocalAuthenticatorConfigs>>
+            <SubjectStep>true</SubjectStep>
+            <AttributeStep>true</AttributeStep>
+        </AuthenticationStep>
+    </AuthenticationSteps>
+</LocalAndOutBoundAuthenticationConfig>
+    <RequestPathAuthenticatorConfigs></RequestPathAuthenticatorConfigs>
+    <InboundProvisioningConfig></InboundProvisioningConfig>
+    <OutboundProvisioningConfig></OutboundProvisioningConfig>
+    <ClaimConfig>
+        <AlwaysSendMappedLocalSubjectId>true</AlwaysSendMappedLocalSubjectId>
+        <LocalClaimDialect>true</LocalClaimDialect><ClaimMappings><ClaimMapping><LocalClaim><ClaimUri>http://wso2.org/claims/givenname</ClaimUri></LocalClaim><RemoteClaim><ClaimUri>http://wso2.org/claims/givenName</ClaimUri>ClaimUri></RemoteClaim><RequestClaim>true</RequestClaim></ClaimMapping></ClaimMappings></ClaimConfig>   
+    <PermissionAndRoleConfig></PermissionAndRoleConfig>
+</ServiceProvider>

--- a/internal/automation-scripts/am-sso-config/am-sp-store.xml
+++ b/internal/automation-scripts/am-sso-config/am-sp-store.xml
@@ -1,0 +1,39 @@
+<ServiceProvider>
+    <ApplicationID>6</ApplicationID>
+    <ApplicationName>am-store</ApplicationName>
+    <Description>APIM Store Service Provider</Description>
+    <IsSaaSApp>true</IsSaaSApp>
+    <InboundAuthenticationConfig>
+        <InboundAuthenticationRequestConfigs>
+            <InboundAuthenticationRequestConfig>
+                <InboundAuthKey>API_STORE</InboundAuthKey>
+                <InboundAuthType>samlsso</InboundAuthType>
+                <Properties></Properties>
+            </InboundAuthenticationRequestConfig>
+        </InboundAuthenticationRequestConfigs>
+    </InboundAuthenticationConfig>
+   
+    <LocalAndOutBoundAuthenticationConfig>
+    <AuthenticationSteps>
+        <AuthenticationStep>
+            <StepOrder>1</StepOrder>
+            <LocalAuthenticatorConfigs>
+                <LocalAuthenticatorConfig>
+                    <Name>BasicAuthenticator</Name>
+                    <DisplayName>basicauth</DisplayName>
+                    <IsEnabled>true</IsEnabled>
+                </LocalAuthenticatorConfig>
+            </LocalAuthenticatorConfigs>>
+            <SubjectStep>true</SubjectStep>
+            <AttributeStep>true</AttributeStep>
+        </AuthenticationStep>
+    </AuthenticationSteps>
+</LocalAndOutBoundAuthenticationConfig>
+    <RequestPathAuthenticatorConfigs></RequestPathAuthenticatorConfigs>
+    <InboundProvisioningConfig></InboundProvisioningConfig>
+    <OutboundProvisioningConfig></OutboundProvisioningConfig>
+    <ClaimConfig>
+        <AlwaysSendMappedLocalSubjectId>true</AlwaysSendMappedLocalSubjectId>
+        <LocalClaimDialect>true</LocalClaimDialect><ClaimMappings><ClaimMapping><LocalClaim><ClaimUri>http://wso2.org/claims/givenname</ClaimUri></LocalClaim><RemoteClaim><ClaimUri>http://wso2.org/claims/givenName</ClaimUri>ClaimUri></RemoteClaim><RequestClaim>true</RequestClaim></ClaimMapping></ClaimMappings></ClaimConfig>   
+    <PermissionAndRoleConfig></PermissionAndRoleConfig>
+</ServiceProvider>

--- a/internal/automation-scripts/am-sso-config/am-sso-idp-config.xml
+++ b/internal/automation-scripts/am-sso-config/am-sso-idp-config.xml
@@ -1,0 +1,200 @@
+<!--
+~ Copyright (c) 2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+ -->
+
+<!-- The full ServiceProvider configuration is as follows. -->
+
+  <!--ServiceProvider>
+    <Issuer></Issuer>
+    <AssertionConsumerServiceURLs>
+      <AssertionConsumerServiceURL></AssertionConsumerServiceURL>
+    </AssertionConsumerServiceURLs>
+    <DefaultAssertionConsumerServiceURL></DefaultAssertionConsumerServiceURL>
+    <EnableSingleLogout>true</EnableSingleLogout>
+    <SLOResponseURL></SLOResponseURL>
+    <SLORequestURL></SLORequestURL>
+    <SAMLDefaultSigningAlgorithmURI>http://www.w3.org/2000/09/xmldsig#rsa-sha1</SAMLDefaultSigningAlgorithmURI>
+    <SAMLDefaultDigestAlgorithmURI>http://www.w3.org/2000/09/xmldsig#sha1</SAMLDefaultDigestAlgorithmURI>
+    <SignResponse>true</SignResponse>
+    <ValidateSignatures>true</ValidateSignatures>
+    <EncryptAssertion>true</EncryptAssertion>
+    <CertAlias></CertAlias>
+    <EnableAttributeProfile>true</EnableAttributeProfile>
+    <IncludeAttributeByDefault>true</IncludeAttributeByDefault>
+    <ConsumingServiceIndex></ConsumingServiceIndex>
+    <EnableAudienceRestriction>false</EnableAudienceRestriction>
+    <AudiencesList>
+      <Audience></Audience>
+    </AudiencesList>
+    <EnableRecipients>false</EnableRecipients>
+    <RecipientList>
+      <Recipient></Recipient>
+    </RecipientList>
+    <EnableIdPInitiatedSSO>false</EnableIdPInitiatedSSO>
+    <EnableIdPInitSLO>false</EnableIdPInitSLO>
+    <ReturnToURLList>
+      <ReturnToURL></ReturnToURL>
+    </ReturnToURLList>
+  </ServiceProvider-->
+
+<SSOIdentityProviderConfig>
+  <ServiceProviders>
+    <ServiceProvider>
+ <Issuer>wso2.my.dashboard</Issuer>
+ <AssertionConsumerServiceURLs>
+ <AssertionConsumerServiceURL>${carbon.protocol}://${carbon.host}:${carbon.management.port}/dashboard/acs</AssertionConsumerServiceURL>
+ </AssertionConsumerServiceURLs>
+ <DefaultAssertionConsumerServiceURL>${carbon.protocol}://${carbon.host}:${carbon.management.port}/dashboard/acs</DefaultAssertionConsumerServiceURL>
+ <SignResponse>true</SignResponse>
+      <EnableAudienceRestriction>true</EnableAudienceRestriction>
+      <AudiencesList>
+        <Audience>carbonServer</Audience>
+      </AudiencesList>
+    </ServiceProvider>
+
+
+    <ServiceProvider>
+        <Issuer>API_PUBLISHER</Issuer>
+        <AssertionConsumerServiceURLs>
+          <AssertionConsumerServiceURL>https://localhost:9443/publisher/jagg/jaggery_acs.jag</AssertionConsumerServiceURL>
+        </AssertionConsumerServiceURLs>
+        <DefaultAssertionConsumerServiceURL>https://localhost:9443/publisher/jagg/jaggery_acs.jag</DefaultAssertionConsumerServiceURL>
+        <EnableSingleLogout>true</EnableSingleLogout>
+        <SLOResponseURL></SLOResponseURL>
+        <SLORequestURL></SLORequestURL>
+        <SAMLDefaultSigningAlgorithmURI>http://www.w3.org/2000/09/xmldsig#rsa-sha1</SAMLDefaultSigningAlgorithmURI>
+        <SAMLDefaultDigestAlgorithmURI>http://www.w3.org/2000/09/xmldsig#sha1</SAMLDefaultDigestAlgorithmURI>
+        <SignResponse>true</SignResponse>
+        <ValidateSignatures>true</ValidateSignatures>
+        <EncryptAssertion>false</EncryptAssertion>
+        <CertAlias></CertAlias>
+        <EnableAttributeProfile>true</EnableAttributeProfile>
+        <IncludeAttributeByDefault>true</IncludeAttributeByDefault>
+        <ConsumingServiceIndex>2104589</ConsumingServiceIndex>
+        <EnableAudienceRestriction>false</EnableAudienceRestriction>
+        <AudiencesList>
+          <Audience></Audience>
+        </AudiencesList>
+        <EnableRecipients>false</EnableRecipients>
+        <RecipientList>
+          <Recipient></Recipient>
+        </RecipientList>
+        <EnableIdPInitiatedSSO>false</EnableIdPInitiatedSSO>
+        <EnableIdPInitSLO>false</EnableIdPInitSLO>
+        <ReturnToURLList>
+          <ReturnToURL></ReturnToURL>
+        </ReturnToURLList>
+    </ServiceProvider>
+    <ServiceProvider>
+        <Issuer>API_STORE</Issuer>
+        <AssertionConsumerServiceURLs>
+          <AssertionConsumerServiceURL>https://localhost:9443/store/jagg/jaggery_acs.jag</AssertionConsumerServiceURL>
+        </AssertionConsumerServiceURLs>
+        <DefaultAssertionConsumerServiceURL>https://localhost:9443/store/jagg/jaggery_acs.jag</DefaultAssertionConsumerServiceURL>
+        <EnableSingleLogout>true</EnableSingleLogout>
+        <SLOResponseURL></SLOResponseURL>
+        <SLORequestURL></SLORequestURL>
+        <SAMLDefaultSigningAlgorithmURI>http://www.w3.org/2000/09/xmldsig#rsa-sha1</SAMLDefaultSigningAlgorithmURI>
+        <SAMLDefaultDigestAlgorithmURI>http://www.w3.org/2000/09/xmldsig#sha1</SAMLDefaultDigestAlgorithmURI>
+        <SignResponse>true</SignResponse>
+        <ValidateSignatures>true</ValidateSignatures>
+        <EncryptAssertion>false</EncryptAssertion>
+        <CertAlias></CertAlias>
+        <EnableAttributeProfile>true</EnableAttributeProfile>
+        <IncludeAttributeByDefault>true</IncludeAttributeByDefault>
+        <ConsumingServiceIndex>2104589</ConsumingServiceIndex>
+        <EnableAudienceRestriction>false</EnableAudienceRestriction>
+        <AudiencesList>
+          <Audience></Audience>
+        </AudiencesList>
+        <EnableRecipients>false</EnableRecipients>
+        <RecipientList>
+          <Recipient></Recipient>
+        </RecipientList>
+        <EnableIdPInitiatedSSO>false</EnableIdPInitiatedSSO>
+        <EnableIdPInitSLO>false</EnableIdPInitSLO>
+        <ReturnToURLList>
+          <ReturnToURL></ReturnToURL>
+        </ReturnToURLList>
+    </ServiceProvider>
+    <ServiceProvider>
+        <Issuer>API_WORKFLOW_ADMIN</Issuer>
+        <AssertionConsumerServiceURLs>
+          <AssertionConsumerServiceURL>https://localhost:9443/admin/jagg/jaggery_acs.jag</AssertionConsumerServiceURL>
+        </AssertionConsumerServiceURLs>
+        <DefaultAssertionConsumerServiceURL>https://localhost:9443/admin/jagg/jaggery_acs.jag</DefaultAssertionConsumerServiceURL>
+        <EnableSingleLogout>true</EnableSingleLogout>
+        <SLOResponseURL></SLOResponseURL>
+        <SLORequestURL></SLORequestURL>
+        <SAMLDefaultSigningAlgorithmURI>http://www.w3.org/2000/09/xmldsig#rsa-sha1</SAMLDefaultSigningAlgorithmURI>
+        <SAMLDefaultDigestAlgorithmURI>http://www.w3.org/2000/09/xmldsig#sha1</SAMLDefaultDigestAlgorithmURI>
+        <SignResponse>true</SignResponse>
+        <ValidateSignatures>true</ValidateSignatures>
+        <EncryptAssertion>false</EncryptAssertion>
+        <CertAlias></CertAlias>
+        <EnableAttributeProfile>true</EnableAttributeProfile>
+        <IncludeAttributeByDefault>true</IncludeAttributeByDefault>
+        <ConsumingServiceIndex>2104589</ConsumingServiceIndex>
+        <EnableAudienceRestriction>false</EnableAudienceRestriction>
+        <AudiencesList>
+          <Audience></Audience>
+        </AudiencesList>
+        <EnableRecipients>false</EnableRecipients>
+        <RecipientList>
+          <Recipient></Recipient>
+        </RecipientList>
+        <EnableIdPInitiatedSSO>false</EnableIdPInitiatedSSO>
+        <EnableIdPInitSLO>false</EnableIdPInitSLO>
+        <ReturnToURLList>
+          <ReturnToURL></ReturnToURL>
+        </ReturnToURLList>
+    </ServiceProvider>
+    <ServiceProvider>
+        <Issuer>carbonServer</Issuer>
+        <AssertionConsumerServiceURLs>
+          <AssertionConsumerServiceURL>https://localhost:9443/acs</AssertionConsumerServiceURL>
+        </AssertionConsumerServiceURLs>
+        <DefaultAssertionConsumerServiceURL>https://localhost:9443/acs</DefaultAssertionConsumerServiceURL>
+        <EnableSingleLogout>true</EnableSingleLogout>
+        <SLOResponseURL></SLOResponseURL>
+        <SLORequestURL></SLORequestURL>
+        <SAMLDefaultSigningAlgorithmURI>http://www.w3.org/2000/09/xmldsig#rsa-sha1</SAMLDefaultSigningAlgorithmURI>
+        <SAMLDefaultDigestAlgorithmURI>http://www.w3.org/2000/09/xmldsig#sha1</SAMLDefaultDigestAlgorithmURI>
+        <SignResponse>true</SignResponse>
+        <ValidateSignatures>true</ValidateSignatures>
+        <EncryptAssertion>false</EncryptAssertion>
+        <CertAlias></CertAlias>
+        <EnableAttributeProfile>true</EnableAttributeProfile>
+        <IncludeAttributeByDefault>true</IncludeAttributeByDefault>
+        <ConsumingServiceIndex>2104589</ConsumingServiceIndex>
+        <EnableAudienceRestriction>false</EnableAudienceRestriction>
+        <AudiencesList>
+          <Audience></Audience>
+        </AudiencesList>
+        <EnableRecipients>false</EnableRecipients>
+        <RecipientList>
+          <Recipient></Recipient>
+        </RecipientList>
+        <EnableIdPInitiatedSSO>false</EnableIdPInitiatedSSO>
+        <EnableIdPInitSLO>false</EnableIdPInitSLO>
+        <ReturnToURLList>
+          <ReturnToURL></ReturnToURL>
+        </ReturnToURLList>
+    </ServiceProvider>
+
+  </ServiceProviders>
+
+
+</SSOIdentityProviderConfig>

--- a/internal/automation-scripts/config/DynamicAdminUser.conf
+++ b/internal/automation-scripts/config/DynamicAdminUser.conf
@@ -1,0 +1,1 @@
+PlaceAdminUserPasswordHere

--- a/internal/automation-scripts/config/DynamicHostnameAM.conf
+++ b/internal/automation-scripts/config/DynamicHostnameAM.conf
@@ -1,0 +1,1 @@
+apim.security.wso2.com

--- a/internal/automation-scripts/config/DynamicHostnameIS.conf
+++ b/internal/automation-scripts/config/DynamicHostnameIS.conf
@@ -1,0 +1,1 @@
+is.security.wso2.com

--- a/internal/automation-scripts/config/StaticScanExcludeFileNames.conf
+++ b/internal/automation-scripts/config/StaticScanExcludeFileNames.conf
@@ -1,0 +1,1 @@
+shindig.war

--- a/internal/automation-scripts/config/StaticScanIncludeFileNamePatterns.conf
+++ b/internal/automation-scripts/config/StaticScanIncludeFileNamePatterns.conf
@@ -1,0 +1,4 @@
+org.jaggeryjs.*.jar
+org.wso2.*.jar
+siddhi-*.jar
+*.war

--- a/internal/automation-scripts/config/SupportedProductList.conf
+++ b/internal/automation-scripts/config/SupportedProductList.conf
@@ -1,0 +1,5 @@
+wso2am-2.1.0
+wso2is-5.3.0
+wso2das-3.1.0
+wso2ei-6.1.1
+wso2iot-3.1.0

--- a/internal/automation-scripts/config/VeracodeLogin.conf
+++ b/internal/automation-scripts/config/VeracodeLogin.conf
@@ -1,0 +1,1 @@
+PlaceVeracodeUsernameHere:PlaceVeracodePasswordHere

--- a/internal/automation-scripts/is-sso-config/is-sp-carbon.xml
+++ b/internal/automation-scripts/is-sso-config/is-sp-carbon.xml
@@ -1,0 +1,39 @@
+<ServiceProvider>
+    <ApplicationID>4</ApplicationID>
+    <ApplicationName>is-carbon</ApplicationName>
+    <Description>IS Carbon Service Provider</Description>
+    <IsSaaSApp>true</IsSaaSApp>
+    <InboundAuthenticationConfig>
+        <InboundAuthenticationRequestConfigs>
+            <InboundAuthenticationRequestConfig>
+                <InboundAuthKey>carbonServer</InboundAuthKey>
+                <InboundAuthType>samlsso</InboundAuthType>
+                <Properties></Properties>
+            </InboundAuthenticationRequestConfig>
+        </InboundAuthenticationRequestConfigs>
+    </InboundAuthenticationConfig>
+
+    <LocalAndOutBoundAuthenticationConfig>
+    <AuthenticationSteps>
+        <AuthenticationStep>
+            <StepOrder>1</StepOrder>
+            <LocalAuthenticatorConfigs>
+                <LocalAuthenticatorConfig>
+                    <Name>BasicAuthenticator</Name>
+                    <DisplayName>basicauth</DisplayName>
+                    <IsEnabled>true</IsEnabled>
+                </LocalAuthenticatorConfig>
+            </LocalAuthenticatorConfigs>>
+            <SubjectStep>true</SubjectStep>
+            <AttributeStep>true</AttributeStep>
+        </AuthenticationStep>
+    </AuthenticationSteps>
+</LocalAndOutBoundAuthenticationConfig>
+    <RequestPathAuthenticatorConfigs></RequestPathAuthenticatorConfigs>
+    <InboundProvisioningConfig></InboundProvisioningConfig>
+    <OutboundProvisioningConfig></OutboundProvisioningConfig>
+    <ClaimConfig>
+        <AlwaysSendMappedLocalSubjectId>true</AlwaysSendMappedLocalSubjectId>
+        <LocalClaimDialect>true</LocalClaimDialect><ClaimMappings><ClaimMapping><LocalClaim><ClaimUri>http://wso2.org/claims/givenname</ClaimUri></LocalClaim><RemoteClaim><ClaimUri>http://wso2.org/claims/givenName</ClaimUri>ClaimUri></RemoteClaim><RequestClaim>true</RequestClaim></ClaimMapping></ClaimMappings></ClaimConfig>
+    <PermissionAndRoleConfig></PermissionAndRoleConfig>
+</ServiceProvider>

--- a/internal/automation-scripts/is-sso-config/is-sso-idp-config.xml
+++ b/internal/automation-scripts/is-sso-config/is-sso-idp-config.xml
@@ -1,0 +1,103 @@
+<!--
+~ Copyright (c) 2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+ -->
+
+<!-- The full ServiceProvider configuration is as follows. -->
+
+  <!--ServiceProvider>
+    <Issuer></Issuer>
+    <AssertionConsumerServiceURLs>
+      <AssertionConsumerServiceURL></AssertionConsumerServiceURL>
+    </AssertionConsumerServiceURLs>
+    <DefaultAssertionConsumerServiceURL></DefaultAssertionConsumerServiceURL>
+    <EnableSingleLogout>true</EnableSingleLogout>
+    <SLOResponseURL></SLOResponseURL>
+    <SLORequestURL></SLORequestURL>
+    <SAMLDefaultSigningAlgorithmURI>http://www.w3.org/2000/09/xmldsig#rsa-sha1</SAMLDefaultSigningAlgorithmURI>
+    <SAMLDefaultDigestAlgorithmURI>http://www.w3.org/2000/09/xmldsig#sha1</SAMLDefaultDigestAlgorithmURI>
+    <SignResponse>true</SignResponse>
+    <ValidateSignatures>true</ValidateSignatures>
+    <EncryptAssertion>true</EncryptAssertion>
+    <CertAlias></CertAlias>
+    <EnableAttributeProfile>true</EnableAttributeProfile>
+    <IncludeAttributeByDefault>true</IncludeAttributeByDefault>
+    <ConsumingServiceIndex></ConsumingServiceIndex>
+    <EnableAudienceRestriction>false</EnableAudienceRestriction>
+    <AudiencesList>
+      <Audience></Audience>
+    </AudiencesList>
+    <EnableRecipients>false</EnableRecipients>
+    <RecipientList>
+      <Recipient></Recipient>
+    </RecipientList>
+    <EnableIdPInitiatedSSO>false</EnableIdPInitiatedSSO>
+    <EnableIdPInitSLO>false</EnableIdPInitSLO>
+    <ReturnToURLList>
+      <ReturnToURL></ReturnToURL>
+    </ReturnToURLList>
+  </ServiceProvider-->
+
+<SSOIdentityProviderConfig>
+  <ServiceProviders>
+    <ServiceProvider>
+ <Issuer>wso2.my.dashboard</Issuer>
+ <AssertionConsumerServiceURLs>
+ <AssertionConsumerServiceURL>${carbon.protocol}://${carbon.host}:${carbon.management.port}/dashboard/acs</AssertionConsumerServiceURL>
+ </AssertionConsumerServiceURLs>
+ <DefaultAssertionConsumerServiceURL>${carbon.protocol}://${carbon.host}:${carbon.management.port}/dashboard/acs</DefaultAssertionConsumerServiceURL>
+ <SignResponse>true</SignResponse>
+      <EnableAudienceRestriction>true</EnableAudienceRestriction>
+      <AudiencesList>
+        <Audience>carbonServer</Audience>
+      </AudiencesList>
+    </ServiceProvider>
+
+    <ServiceProvider>
+        <Issuer>carbonServer</Issuer>
+        <AssertionConsumerServiceURLs>
+          <AssertionConsumerServiceURL>https://localhost:9443/acs</AssertionConsumerServiceURL>
+        </AssertionConsumerServiceURLs>
+        <DefaultAssertionConsumerServiceURL>https://localhost:9443/acs</DefaultAssertionConsumerServiceURL>
+        <EnableSingleLogout>true</EnableSingleLogout>
+        <SLOResponseURL></SLOResponseURL>
+        <SLORequestURL></SLORequestURL>
+        <SAMLDefaultSigningAlgorithmURI>http://www.w3.org/2000/09/xmldsig#rsa-sha1</SAMLDefaultSigningAlgorithmURI>
+        <SAMLDefaultDigestAlgorithmURI>http://www.w3.org/2000/09/xmldsig#sha1</SAMLDefaultDigestAlgorithmURI>
+        <SignResponse>true</SignResponse>
+        <ValidateSignatures>true</ValidateSignatures>
+        <EncryptAssertion>false</EncryptAssertion>
+        <CertAlias></CertAlias>
+        <EnableAttributeProfile>true</EnableAttributeProfile>
+        <IncludeAttributeByDefault>true</IncludeAttributeByDefault>
+        <ConsumingServiceIndex>2104589</ConsumingServiceIndex>
+        <EnableAudienceRestriction>false</EnableAudienceRestriction>
+        <AudiencesList>
+          <Audience></Audience>
+        </AudiencesList>
+        <EnableRecipients>false</EnableRecipients>
+        <RecipientList>
+          <Recipient></Recipient>
+        </RecipientList>
+        <EnableIdPInitiatedSSO>false</EnableIdPInitiatedSSO>
+        <EnableIdPInitSLO>false</EnableIdPInitSLO>
+        <ReturnToURLList>
+          <ReturnToURL></ReturnToURL>
+        </ReturnToURLList>
+    </ServiceProvider>
+
+  </ServiceProviders>
+
+
+</SSOIdentityProviderConfig>

--- a/internal/automation-scripts/scheduled/Daily.sh
+++ b/internal/automation-scripts/scheduled/Daily.sh
@@ -1,3 +1,19 @@
+#!/bin/sh
+
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 LOG_HOME="$HOME/outputs"
 
 date=$(date -d "today" +"%Y-%m-%d")

--- a/internal/automation-scripts/scheduled/Daily.sh
+++ b/internal/automation-scripts/scheduled/Daily.sh
@@ -1,0 +1,10 @@
+LOG_HOME="$HOME/outputs"
+
+date=$(date -d "today" +"%Y-%m-%d")
+if [ ! -d "$LOG_HOME/$date" ]; then
+	mkdir -p $LOG_HOME/$date
+fi
+
+timestamp=$(date -d "today" +"%Y-%m-%d-%H.%M.%S")
+
+bash $HOME/scripts/RunDependencyCheck.sh 2>&1 | tee -a $LOG_HOME/$date/daily-scan-dependency-check-$timestamp.log

--- a/internal/automation-scripts/scheduled/Weekly.sh
+++ b/internal/automation-scripts/scheduled/Weekly.sh
@@ -1,0 +1,11 @@
+LOG_HOME="$HOME/outputs"
+
+date=$(date -d "today" +"%Y-%m-%d")
+if [ ! -d "$LOG_HOME/$date" ]; then
+	mkdir -p $LOG_HOME/$date
+fi
+
+timestamp=$(date -d "today" +"%Y-%m-%d-%H.%M.%S")
+
+bash $HOME/scripts/BuildDynamicScanEnv.sh 2>&1 | tee -a $LOG_HOME/$date/weekly-scan-dynamic-$timestamp.log
+bash $HOME/scripts/BuildStaticScanZip.sh 2>&1 | tee -a $LOG_HOME/$date/weekly-scan-static-$timestamp.log

--- a/internal/automation-scripts/scheduled/Weekly.sh
+++ b/internal/automation-scripts/scheduled/Weekly.sh
@@ -1,3 +1,19 @@
+#!/bin/sh
+
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 LOG_HOME="$HOME/outputs"
 
 date=$(date -d "today" +"%Y-%m-%d")

--- a/internal/automation-scripts/setup/SetupDefectDojo.sh
+++ b/internal/automation-scripts/setup/SetupDefectDojo.sh
@@ -1,0 +1,68 @@
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TOOL_HOME="$HOME/tools"
+TOOL_DOWNLOAD_REPO="https://github.com/OWASP/django-DefectDojo"
+TOOL_DOWNLOAD_REPO_TAG_OR_BRANCH="master"
+TOOL_NAME="defect-dojo-$TOOL_DOWNLOAD_REPO_TAG_OR_BRANCH"
+
+SCRIPT_TAG="[SEC_AUTOMATION_SETUP_DEFECTDOJO]"
+
+echo "$SCRIPT_TAG [START]"
+
+# Create tools folder if not present
+if [ ! -d ${TOOL_HOME} ]; then
+  mkdir ${TOOL_HOME}
+  echo "$SCRIPT_TAG Created ${TOOL_HOME}"
+fi
+
+# Create backup folder if not present
+if [ ! -d "$TOOL_HOME/backup" ]; then
+  mkdir "$TOOL_HOME/backup"
+  echo "$SCRIPT_TAG Created $TOOL_HOME/backup"
+fi
+
+# Backup and cleanup the Dependency Check home folder
+if [ -d "$TOOL_HOME/$TOOL_NAME" ]; then
+  #TODO: Remove next two lines after configuration automation is done
+  echo "$SCRIPT_TAG Tool already present"
+  exit
+
+  timestamp=$(date -d "today" +"%Y-%m-%d-%H.%M.%S")
+  mv "$TOOL_HOME/$TOOL_NAME" "$TOOL_HOME/backup/$TOOL_NAME-$timestamp"
+  echo "$SCRIPT_TAG Moved existing version to $TOOL_HOME/backup/$TOOL_NAME-$timestamp"
+fi
+mkdir "$TOOL_HOME/$TOOL_NAME"
+
+# Cleanup the temp folder, just in case previous entry was present
+rm -rf /tmp/$TOOL_NAME
+mkdir /tmp/$TOOL_NAME
+
+# Download Dependency Check and extract into tool folder
+echo "$SCRIPT_TAG Downloading $TOOL_NAME to /tmp/$TOOL_NAME"
+wget -q --show-progress $TOOL_DOWNLOAD_REPO/archive/$TOOL_DOWNLOAD_REPO_TAG_OR_BRANCH.zip -P /tmp/$TOOL_NAME
+unzip -q /tmp/$TOOL_NAME/$TOOL_DOWNLOAD_REPO_TAG_OR_BRANCH.zip -d  $TOOL_HOME/$TOOL_NAME
+SUB_FOLDER_NAME=$(ls -l $TOOL_HOME/$TOOL_NAME | tr -s ' ' | cut -d ' ' -f9 | grep -v -e '^$')
+mv $TOOL_HOME/$TOOL_NAME/$SUB_FOLDER_NAME/* $TOOL_HOME/$TOOL_NAME
+rm -rf $TOOL_HOME/$TOOL_NAME/$SUB_FOLDER_NAME
+echo "$SCRIPT_TAG Extracted $TOOL_NAME to $TOOL_HOME/$TOOL_NAME"
+
+# Clean the temp folder
+rm -rf /tmp/$TOOL_NAME
+echo "$SCRIPT_TAG Removed /tmp/$TOOL_NAME"
+
+# TODO: Automate configuration changes and show diffs
+echo "$SCRIPT_TAG Tool setup is done at $TOOL_HOME/$TOOL_NAME. Please proceed with manual configuration"
+
+echo "$SCRIPT_TAG [END]"

--- a/internal/automation-scripts/setup/SetupDefectDojo.sh
+++ b/internal/automation-scripts/setup/SetupDefectDojo.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/automation-scripts/setup/SetupDependencyCheck.sh
+++ b/internal/automation-scripts/setup/SetupDependencyCheck.sh
@@ -1,0 +1,75 @@
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TOOL_HOME="$HOME/tools"
+TOOL_NAME="dependency-check-3.0.1"
+TOOL_DOWNLOAD_URL_FOLDER="http://dl.bintray.com/jeremy-long/owasp"
+TOOL_DOWNLOAD_URL_FILE="dependency-check-3.0.1-release.zip"
+SCRIPT_TAG="[SEC_AUTOMATION_UPDATE_PRODUCTS]"
+
+echo "$SCRIPT_TAG [START]"
+
+# Create tools folder if not present
+if [ ! -d ${TOOL_HOME} ]; then
+  mkdir ${TOOL_HOME}
+  echo "$SCRIPT_TAG Created ${TOOL_HOME}"
+fi
+
+# Create backup folder if not present
+if [ ! -d "$TOOL_HOME/backup" ]; then
+  mkdir "$TOOL_HOME/backup"
+  echo "$SCRIPT_TAG Created $TOOL_HOME/backup"
+fi
+
+# Backup and cleanup the Dependency Check home folder
+if [ -d "$TOOL_HOME/$TOOL_NAME" ]; then
+  timestamp=$(date -d "today" +"%Y-%m-%d-%H.%M.%S")
+  mv "$TOOL_HOME/$TOOL_NAME" "$TOOL_HOME/backup/$TOOL_NAME-$timestamp"
+  echo "$SCRIPT_TAG Moved existing version to $TOOL_HOME/backup/$TOOL_NAME-$timestamp"
+fi
+mkdir "$TOOL_HOME/$TOOL_NAME"
+
+# Cleanup the temp folder, just in case previous entry was present
+rm -rf /tmp/$TOOL_NAME
+mkdir /tmp/$TOOL_NAME
+
+# Download Dependency Check and extract into tool folder
+echo "$SCRIPT_TAG Downloading Dependency Check to /tmp/$TOOL_NAME"
+wget -q --show-progress $TOOL_DOWNLOAD_URL_FOLDER/$TOOL_DOWNLOAD_URL_FILE -P /tmp/$TOOL_NAME
+unzip -q /tmp/$TOOL_NAME/$TOOL_DOWNLOAD_URL_FILE -d  $TOOL_HOME/$TOOL_NAME
+SUB_FOLDER_NAME=$(ls -l $TOOL_HOME/$TOOL_NAME | tr -s ' ' | cut -d ' ' -f9 | grep -v -e '^$')
+mv $TOOL_HOME/$TOOL_NAME/$SUB_FOLDER_NAME/* $TOOL_HOME/$TOOL_NAME
+rm -rf $TOOL_HOME/$TOOL_NAME/$SUB_FOLDER_NAME
+echo "$SCRIPT_TAG Extracted Dependency Check to $TOOL_HOME/$TOOL_NAME"
+
+# Clean the temp folder
+rm -rf /tmp/$TOOL_NAME
+echo "$SCRIPT_TAG Removed /tmp/$TOOL_NAME"
+
+# Applying custom modifications
+echo "$SCRIPT_TAG Downloading Security-Tools repo to /tmp/$TOOL_NAME"
+wget -q --show-progress https://github.com/wso2/security-tools/archive/master.zip -P /tmp/$TOOL_NAME
+unzip -q /tmp/$TOOL_NAME/master.zip -d /tmp/$TOOL_NAME
+cd /tmp/$TOOL_NAME/security-tools-master/external/dependency-check-core-3.0.1
+mvn clean install -DskipTests=true
+
+rm $TOOL_HOME/$TOOL_NAME/repo/org/owasp/dependency-check-core/3.0.1/dependency-check-core-3.0.1.jar
+cp /tmp/$TOOL_NAME/security-tools-master/external/dependency-check-core-3.0.1/target/dependency-check-core-3.0.1.jar $TOOL_HOME/$TOOL_NAME/repo/org/owasp/dependency-check-core/3.0.1/
+echo "$SCRIPT_TAG Replaced modification in $TOOL_HOME/$TOOL_NAME/repo/org/owasp/dependency-check-core/3.0.1/dependency-check-core-3.0.1.jar"
+
+# Clean the temp folder
+rm -rf /tmp/$TOOL_NAME
+echo "$SCRIPT_TAG Removed /tmp/$TOOL_NAME"
+
+echo "$SCRIPT_TAG [END]"

--- a/internal/automation-scripts/setup/SetupDependencyCheck.sh
+++ b/internal/automation-scripts/setup/SetupDependencyCheck.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/automation-scripts/setup/SetupScriptDependencies.sh
+++ b/internal/automation-scripts/setup/SetupScriptDependencies.sh
@@ -1,0 +1,5 @@
+sudo apt-get update
+sudo apt-get install -y unzip
+sudo apt-get install -y zip
+sudo apt-get install -y wget
+sudo apt-get install -y curl

--- a/internal/automation-scripts/setup/SetupScriptDependencies.sh
+++ b/internal/automation-scripts/setup/SetupScriptDependencies.sh
@@ -1,3 +1,19 @@
+#!/bin/sh
+
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 sudo apt-get update
 sudo apt-get install -y unzip
 sudo apt-get install -y zip


### PR DESCRIPTION
## Purpose
> Scanning WSO2 products with security automation tools (Veracode, Qualys, OWASP Dependency Check, etc.) required manual extraction of certain files, manual interactions with external services and frequent re-configuration of products with WUM updates applied. This process consumed unnecessary time with each scan iteration. 

## Goals
> It was essential to automate every aspect of Static, Dynamic and Dependency security scanning including environment setup, scan submission and report retrieval. Environment-setup and scan submission needs to be given priority.

## Approach
> Set of shell (bash) scripts were written to automate the WUM update retrieval, dynamic environment setup, static scan artifact gathering, static scan submission, and performing dependency scans.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? no (not applicable for scripts)
 - Ran FindSecurityBugs plugin and verified report? no (not applicable for scripts)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Place scripts in "$HOME/scripts" folder. Other required paths will be created automatically by scripts. To setup the environment, execute scripts from "$HOME/scripts/setup" 
 
## Learning
> Veracode API, Qualys scan scheduling, different bash scripting techniques.