### PR TITLE
Cleaning veracode builds before scans

### DIFF
--- a/internal/automation-scripts/BuildDynamicScanEnv.sh
+++ b/internal/automation-scripts/BuildDynamicScanEnv.sh
@@ -42,8 +42,8 @@ fi
 echo "$SCRIPT_TAG Cleaning dynamic environment home: $DYNAMIC_HOME"
 rm -rf $DYNAMIC_HOME
 
-echo "$SCRIPT_TAG Calling WUM update process"
-bash $HOME/scripts/UpdateProducts.sh
+#echo "$SCRIPT_TAG Calling WUM update process"
+#bash $HOME/scripts/UpdateProducts.sh
 
 cp -R $PRODUCT_HOME $DYNAMIC_HOME
 echo "$SCRIPT_TAG Copied $PRODUCT_HOME to $DYNAMIC_HOME"

--- a/internal/automation-scripts/BuildStaticScanZip.sh
+++ b/internal/automation-scripts/BuildStaticScanZip.sh
@@ -19,13 +19,13 @@ SCRIPT_TAG="[SEC_AUTOMATION_BUILD_STSTIC_ZIP]"
 
 echo "$SCRIPT_TAG [START]"
 
-echo "$SCRIPT_TAG Calling WUM update process"
-bash $HOME/scripts/UpdateProducts.sh
+#echo "$SCRIPT_TAG Calling WUM update process"
+#bash $HOME/scripts/UpdateProducts.sh
 
 echo "$SCRIPT_TAG Cleaning static environment home: $STATIC_HOME"
 rm -rf $STATIC_HOME
 
-cp -R $PRODUCT_HOME $STATIC_HOME
+cp -R $STATIC_HOME
 echo "$SCRIPT_TAG Copied $PRODUCT_HOME to $STATIC_HOME"
 
 for product in $(cat $HOME/scripts/config/SupportedProductList.conf)
@@ -67,14 +67,19 @@ do
 
 		VERACODE_APP_ID=-1
 		if [[ $product == *"wso2am"* ]]; then
+			# <app app_id="328371" app_name="wso2am-2.1.0" policy_updated_date="2017-12-21T08&#x3a;47&#x3a;33-05&#x3a;00"/>
 			VERACODE_APP_ID=328371
 		elif [[ $product == *"wso2is"* ]]; then
+			# <app app_id="328089" app_name="wso2is-5.3.0" policy_updated_date="2017-12-21T06&#x3a;51&#x3a;37-05&#x3a;00"/>
 			VERACODE_APP_ID=328089
 		elif [[ $product == *"wso2iot"* ]]; then
-			VERACODE_APP_ID=217912 #is master
+			# <app app_id="392456" app_name="Application 06" policy_updated_date="2018-01-02T21&#x3a;37&#x3a;15-05&#x3a;00"/>
+			VERACODE_APP_ID=392456 #is master
 		elif [[ $product == *"wso2das"* ]]; then
+			# <app app_id="218676" app_name="veracode-carbon-data" policy_updated_date="2017-12-21T05&#x3a;13&#x3a;44-05&#x3a;00"/>
 			VERACODE_APP_ID=218676 #carbon
 		elif [[ $product == *"wso2ei"* ]]; then
+			# <app app_id="328373" app_name="Application 03" policy_updated_date="2017-12-21T04&#x3a;38&#x3a;33-05&#x3a;00"/>
 			VERACODE_APP_ID=328373
 		else
 			echo "$SCRIPT_TAG [ERROR] Unknown product, skipping configuration"
@@ -83,10 +88,17 @@ do
 			echo "$SCRIPT_TAG [ERROR] THIS SHOULD NOT PRINT"
 		fi
 
+		timestamp=$(date -d "today" +"%Y-%m-%d-%H.%M.%S")
 		if [[ $VERACODE_APP_ID > -1 ]]; then
+			echo "$SCRIPT_TAG Removing previous builds"
+			for build_id in $(curl -q --compressed -u $(cat $HOME/scripts/config/VeracodeLogin.conf) https://analysiscenter.veracode.com/api/5.0/getbuildlist.do -F "app_id=$VERACODE_APP_ID" | grep build_id | cut -d "\"" -f2); do
+				echo "$SCRIPT_TAG Removing build ID $build_id"
+				curl -q --progress-bar --compressed -u $(cat $HOME/scripts/config/VeracodeLogin.conf) https://analysiscenter.veracode.com/api/5.0/deletebuild.do -F "app_id=$VERACODE_APP_ID"
+			done
 			echo "$SCRIPT_TAG Submitting veracode scan for $STATIC_HOME/$product-scan.zip with app ID: $VERACODE_APP_ID."
+			curl -q --progress-bar --compressed -u $(cat $HOME/scripts/config/VeracodeLogin.conf) https://analysiscenter.veracode.com/api/5.0/createbuild.do -F "app_id=$VERACODE_APP_ID" -F "version=AUTO_SCAN_$timestamp"
 			curl -q --progress-bar --compressed -u $(cat $HOME/scripts/config/VeracodeLogin.conf) https://analysiscenter.veracode.com/api/5.0/uploadfile.do -F "app_id=$VERACODE_APP_ID" -F "file=@$STATIC_HOME/$product-scan.zip"
-			curl -q --progress-bar --compressed -u $(cat $HOME/scripts/config/VeracodeLogin.conf) https://analysiscenter.veracode.com/api/5.0/beginprescan.do -F "app_id=$VERACODE_APP_ID" -F "auto_scan=true"
+			curl -q --progress-bar --compressed -u $(cat $HOME/scripts/config/VeracodeLogin.conf) https://analysiscenter.veracode.com/api/5.0/beginprescan.do -F "app_id=$VERACODE_APP_ID" -F "auto_scan=true" -F "scan_all_nonfatal_top_level_modules=true"
 		fi
 done
 

--- a/internal/automation-scripts/UpdateProducts.sh
+++ b/internal/automation-scripts/UpdateProducts.sh
@@ -19,6 +19,10 @@ SCRIPT_TAG="[SEC_AUTOMATION_UPDATE_PRODUCTS]"
 
 echo "$SCRIPT_TAG [START]"
 
+echo "$SCRIPT_TAG Cleaning WUM products and updates"
+rm -rf ~/.wum-wso2/products
+rm -rf ~/.wum-wso2/updates
+
 echo "$SCRIPT_TAG Cleaning product home: ($PRODUCT_HOME)"
 rm -rf $PRODUCT_HOME
 mkdir $PRODUCT_HOME


### PR DESCRIPTION
## Purpose
> Veracode scan reports get accumulated results when doing scans one after another. This could introduce problems, since a separate VMS is used to maintain vulnerabilities.

## Goals
> Cleaning Veracode builds before scans, so that results do not get accumulated. 

## Approach
> Calling Veracode API to clear builds and previous records.  

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? no (scripts only)
 - Ran FindSecurityBugs plugin and verified report? no (scripts only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/Ae

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A