### PR TITLE
Improved suppression file so that same can be used across WSO2 products and  open source projects lead by WSO2

### DIFF
--- a/external/dependency-check-resources/wso2-suppressions.xml
+++ b/external/dependency-check-resources/wso2-suppressions.xml
@@ -2,28 +2,28 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
     <suppress>
         <notes><![CDATA[
-            Eclipse IDE related issues are not relevant to WSO2 products.
+            Issue is a only relevant to Eclipse IDE. The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\.jar</filePath>
         <cpe>cpe:/a:eclipse:eclipse_ide</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Eclipse Business Intelligence and Reporting Tools (BIRT) related issues are not relevant to WSO2 products.
+            Issue is only relevant to Eclipse Business Intelligence and Reporting Tools (BIRT). The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\.jar</filePath>
         <cpe>cpe:/a:eclipse:birt</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            NTP (Network Time Protocol) daemon related issues are not relevant to WSO2 products
+            Issue is only relevant to NTP (Network Time Protocol) daemon. The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\.jar</filePath>
         <cpe>cpe:/a:ntp:ntp</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is relevant to "JasPer Image Coding Toolkit" [1]. This library if not used in WSO2 products. 
+            Issue is only relevant to "JasPer Image Coding Toolkit" [1]. The flagged component is not used in this project. 
             OWASP Dependency Check incorrectly identifies "JasPer" instead of "jsp.jasper".
             [1] https://github.com/mdadams/jasper
         ]]></notes>
@@ -32,129 +32,119 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is not relevant to Axis2 Mail Transport. This issue is applicable only for Axis2 core.
+            Issue is not relevant to Axis2 Mail Transport. This issue is applicable only for Axis2 core. Please check the issues reported against Axis2 core for further details. 
         ]]></notes>
         <filePath regex="true">.*\baxis2-transport-mail_.*\.jar</filePath>
         <cpe>cpe:/a:apache:axis2</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is not relevant to Axis2 JMS Transport. This issue is applicable only for Axis2 core.
+            Issue is not relevant to Axis2 JMS Transport. This issue is applicable only for Axis2 core. Please check the issues reported against Axis2 core for further details. 
         ]]></notes>
         <filePath regex="true">.*\baxis2-transport-jms_.*\.jar</filePath>
         <cpe>cpe:/a:apache:axis2</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is not relevant to Axis2 RabbitMQ AMQP Transport. This issue is applicable only for Axis2 core.
+            Issue is not relevant to Axis2 RabbitMQ AMQP Transport. This issue is applicable only for Axis2 core. Please check the issues reported against Axis2 core for further details. 
         ]]></notes>
         <filePath regex="true">.*\baxis2-transport-rabbitmq-amqp_.*\.jar</filePath>
         <cpe>cpe:/a:apache:axis2</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is not relevant to Geronimo SAAJ library. This issue is applicable only for Geranimo core.
+            Issue is not relevant to Geronimo SAAJ library. This issue is applicable only for Geranimo core. Please check the issues reported against Geranimo core for further details. 
         ]]></notes>
         <filePath regex="true">.*\bgeronimo-saaj_1.3_spec_.*\.jar</filePath>
         <cpe>cpe:/a:apache:geronimo</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is not relevant to JDBC Pool library. This issue is applicable only for Apache Tomcat servlet container.
+            Issue is not relevant to JDBC Pool library. This issue is applicable only for Apache Tomcat servlet container. Please check the issues reported against Apache Tomcat servlet container for further details. 
         ]]></notes>
         <filePath regex="true">.*\bjdbc-pool_.*\.jar</filePath>
         <cpe>cpe:/a:apache:tomcat</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is only applicable for the init script for Apache Geronimo on SUSE Linux (when performing a chown operation).
-            Not applirable for WSO2 products. 
+            Issue is only applicable for the init script for Apache Geronimo on SUSE Linux (when performing a chown operation). The flagged component is not used in this project. 
         ]]></notes>
         <cve>CVE-2008-0732</cve>
         <cpe>cpe:/a:apache:geronimo</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is not relevant to Tomcat Annotations API library. This issue is applicable only for Apache Tomcat servlet container.
+            Issue is not relevant to Tomcat Annotations API library. This issue is applicable only for Apache Tomcat servlet container. Please check the issues reported against Apache Tomcat servlet container for further details. 
         ]]></notes>
         <filePath regex="true">.*\btomcat-annotations-api-.*\.jar</filePath>
         <cpe>cpe:/a:apache:tomcat</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is not relevant to Hadoop Client library. This issue is only applicable for authentication in Apache Hadoop server.
+            Issue is not relevant to Hadoop Client library. This issue is only applicable for authentication in Apache Hadoop server. The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\bhadoop-client_.*\.jar</filePath>
         <cve>CVE-2016-5393</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is not relevant to Hadoop Client library. This issue is only applicable for YARN NodeManager in Apache Hadoop server.
+            Issue is not relevant to Hadoop Client library. This issue is only applicable for YARN NodeManager in Apache Hadoop server. The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\bhadoop-client_.*\.jar</filePath>
         <cve>CVE-2016-3086</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is not relevant to Hadoop Client library. This issue is only applicable for short-circuit reads feature of HDFS in Apache Hadoop server.
+            Issue is not relevant to Hadoop Client library. This issue is only applicable for short-circuit reads feature of HDFS in Apache Hadoop server. The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\bhadoop-client_.*\.jar</filePath>
         <cve>CVE-2016-5001</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is not relevant to Hadoop Client library. This issue is only applicable for Hadoop connector 
-            for IBM Spectrum Scale and General Parallel File System.
+            Issue is not relevant to Hadoop Client library. This issue is only applicable for Hadoop connector for IBM Spectrum Scale and General Parallel File System. The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\bhadoop-client_.*\.jar</filePath>
         <cve>CVE-2015-7430</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            This is an issue with MyOpenID server. The issue is not applicable for openid4java library or WSO2 products. 
-            DependencyCheck team has fixed misidentification and fix is pending-release. [1] 
-            [1] https://github.com/jeremylong/DependencyCheck/issues/713
+            This is an issue with MyOpenID server. The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\.jar</filePath>
         <cve>CVE-2007-1652</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            This is an issue with MyOpenID server. The issue is not applicable for openid4java library or WSO2 products.  
+            This is an issue with MyOpenID server. The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\.jar</filePath>
         <cve>CVE-2007-1651</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is reported on "Apache Geronimo 2.2.1" server runtime. WSO2 products are not using Geronimo runtime.
-            Hence, this issue is not applicable for WSO2 products. 
+            Issue is reported on "Apache Geronimo 2.2.1" server runtime. The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\.jar</filePath>
         <cve>CVE-2011-5034</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is reported on "Apache Geronimo" server runtime init script for "SUSE Linux". WSO2 products are only using "geronimo-stax-api_1.0".
-            Hence, this issue is not applicable for WSO2 products.
+            Issue is reported on "Apache Geronimo" server runtime init script for "SUSE Linux". The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\.jar</filePath>
         <cve>CVE-2008-0732</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            This issue is related to how Apache Struts 1 uses comons-beanutil [1]. CVE is basically for Struts. 
-            There is no impact on usage pattern of Apache Tiles JSP. 
-            
-            [1] http://mail-archives.apache.org/mod_mbox/struts-announcements/201404.mbox/%3C535F5F52.4040108%40apache.org%3E
+            This issue is related to how Apache Struts 1 uses comons-beanutil [1]. CVE is basically for Struts. The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\.jar</filePath>
         <cve>CVE-2014-0114</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Axis 2 host name verification happens at HttpClient level. Relevant HttpClient version used in Axis2 has been patched by 
-            WSO2 to perform required host name verification. Please refer to [1] for the fork history of HttpClient. 
+            Axis 2 host name verification happens at HttpClient level. Relevant HttpClient version used in Axis2 has been patched by WSO2 to perform required host name verification. Please refer to [1] for the fork history of HttpClient. 
 
             [1] https://github.com/wso2/wso2-commons-httpclient/commits/master?after=e6b98d752b17b8c772ce421bae47e1bd15e8cf6c+34
         ]]></notes>
@@ -183,53 +173,87 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is not relevant to EL API library. This issue is applicable only for Apache Tomcat servlet container.
+            Issue is not relevant to EL API library. This issue is applicable only for Apache Tomcat servlet container.  Please check the issues reported against Apache Tomcat servlet container for further details. 
         ]]></notes>
         <gav regex="true">^org\.apache\.tomcat:el-api:.*$</gav>
         <cpe>cpe:/a:apache:tomcat</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is not relevant to Jasper EL library. This issue is applicable only for Apache Tomcat servlet container.
+            Issue is not relevant to Jasper EL library. This issue is applicable only for Apache Tomcat servlet container.  Please check the issues reported against Apache Tomcat servlet container for further details. 
         ]]></notes>
         <gav regex="true">^org\.apache\.tomcat:jasper-el:.*$</gav>
         <cpe>cpe:/a:apache:tomcat</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            This is a disputed issue related to Apache Tomcat servlet and JSP engine  and JBoss
+            This is a disputed issue related to Apache Tomcat servlet and JSP engine and JBoss
         ]]></notes>
         <filePath regex="true">.*\.jar</filePath>
         <cpe>CVE-2013-2185</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Only  the POM file "jetty-http/pom.xml" exists in storm-core_0.10.1.wso2v1.jar. 
-            jerry-http is not included in storm-core JAR or not shipped with product. 
+            Only the POM file "jetty-http/pom.xml" exists in storm-core_0.10.1.wso2v1.jar. jerry-http is not included in storm-core JAR or not shipped with this project. 
         ]]></notes>
         <gav regex="true">^org\.eclipse\.jetty:jetty-client:.*$</gav>
         <cve>CVE-2017-9735</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-            Issue is relevant to C cli shell in Apache Zookeeper which is not used in WSO2 products.
+            Issue is relevant to C cli shell in Apache Zookeeper. The flagged component is not used in this project. 
         ]]></notes>
         <filePath regex="true">.*\.jar</filePath>
         <cve>CVE-2016-5017</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-           Issue is not relevant to CXF XJC toString Plugin. This issue is applicable only for Apache CXF core.
+           Issue is not relevant to CXF XJC toString Plugin. This issue is applicable only for Apache CXF core. Please check the issues reported against Apache CXF core for further details. 
         ]]></notes>
         <filePath regex="true">.*\bcxf-xjc-bug.*\.jar</filePath>
         <cpe>cpe:/a:apache:cxf</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-           Issue is not relevant to CXF XJC toString Plugin. This issue is applicable only for Apache CXF core.
+           Issue is not relevant to CXF XJC toString Plugin. This issue is applicable only for Apache CXF core. Please check the issues reported against Apache CXF core for further details. 
         ]]></notes>
         <filePath regex="true">.*\bcxf-xjc-ts-.*\.jar</filePath>
         <cpe>cpe:/a:apache:cxf</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            Issue is only relevant to RESTful web services module for Drupal. The flagged component is not used in this project. 
+        ]]></notes>
+        <filePath regex="true">.*\bjavax.ws.rs-api-.*\.jar</filePath>
+        <cpe>cpe:/a:restful_project:restful</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            Issue is only relevant to RESTful web services module for Drupal. The flagged component is not used in this project. 
+        ]]></notes>
+        <filePath regex="true">.*\bjavax.ws.rs-api-.*\.jar</filePath>
+        <cpe>cpe:/a:restful_web_services_project:restful_web_services</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            Issue is only relevant to RESTful web services module for Drupal. The flagged component is not used in this project. 
+        ]]></notes>
+        <filePath regex="true">.*\bairline-.*\.jar</filePath>
+        <cpe>cpe:/a:git_project:git</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            Airline is a "Java annotation-based framework for parsing Git like command line structures." The reported issue is only relevant to Git project. Hence, the flagged component is not used in this project. 
+        ]]></notes>
+        <filePath regex="true">.*\bairline-.*\.jar</filePath>
+        <cpe>cpe:/a:git_project:git</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            Airline is a "Java annotation-based framework for parsing Git like command line structures." The reported issue is only relevant to Git project. Hence, the flagged component is not used in this project. 
+        ]]></notes>
+        <filePath regex="true">.*\bairline-.*\.jar</filePath>
+        <cpe>cpe:/a:git:git</cpe>
     </suppress>
 
     <suppress>


### PR DESCRIPTION
## Purpose
> The suppression file will be used across WSO2 products and some open source projects lead by WSO2. Therefore, it is not accurate to have mentions such as "not applicable to WSO2 products" in the suppressions. Changed such mentions to appear generic and correct generic miss-identifications across the projects.  

## Goals
> Modify suppression files as necessary

## Approach
> Clean-up suppression descriptions, so that the same file can be used across WSO2 products and open source projects lead by WSO2. 