### PR TITLE
Use common artifact-id format

### DIFF
--- a/internal/scan-manager/common/common/pom.xml
+++ b/internal/scan-manager/common/common/pom.xml
@@ -31,9 +31,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.wso2.security.tools.scanmanager</groupId>
-    <artifactId>org.wso2.security.tools.scanmanager.common</artifactId>
+    <artifactId>scan-manager-common</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
     <name>Scan Manager - Common</name>
-    
+
 </project>

--- a/internal/scan-manager/common/external/pom.xml
+++ b/internal/scan-manager/common/external/pom.xml
@@ -31,7 +31,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.wso2.security.tools.scanmanager</groupId>
-    <artifactId>org.wso2.security.tools.scanmanager.common.external</artifactId>
+    <artifactId>scan-manager-common-external</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
     <name>Scan Manager - Common - External</name>
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.wso2.security.tools.scanmanager</groupId>
-            <artifactId>org.wso2.security.tools.scanmanager.common</artifactId>
+            <artifactId>scan-manager-common</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/internal/scan-manager/common/internal/pom.xml
+++ b/internal/scan-manager/common/internal/pom.xml
@@ -31,15 +31,15 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.wso2.security.tools.scanmanager</groupId>
-    <artifactId>org.wso2.security.tools.scanmanager.common.internal</artifactId>
+    <artifactId>scan-manager-common-internal</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
-    <name>Scan Manager - Common - External</name>
+    <name>Scan Manager - Common - Internal</name>
 
     <dependencies>
         <dependency>
             <groupId>org.wso2.security.tools.scanmanager</groupId>
-            <artifactId>org.wso2.security.tools.scanmanager.common</artifactId>
+            <artifactId>scan-manager-common</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/internal/scan-manager/core/pom.xml
+++ b/internal/scan-manager/core/pom.xml
@@ -31,7 +31,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.wso2.security.tools.scanmanager</groupId>
-  <artifactId>core</artifactId>
+  <artifactId>scan-manager-core</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>war</packaging>
 

--- a/internal/scan-manager/scanners/common/pom.xml
+++ b/internal/scan-manager/scanners/common/pom.xml
@@ -18,7 +18,7 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
@@ -31,7 +31,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.wso2.security.tools.scanmanager</groupId>
-    <artifactId>scanners-common</artifactId>
+    <artifactId>scan-manager-scanners-common</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <name>Scan Manager - Scanner - Common</name>

--- a/internal/scan-manager/webapp/pom.xml
+++ b/internal/scan-manager/webapp/pom.xml
@@ -30,7 +30,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.security.tools.scanmanager</groupId>
-    <artifactId>webapp</artifactId>
+    <artifactId>scan-manager-webapp</artifactId>
     <packaging>war</packaging>
     <version>1.0-SNAPSHOT</version>
 


### PR DESCRIPTION
## Purpose
Currently scan-managers uses maven artifact IDs with different formats. 

## Goals
Update artifact ID to use a common format. 

## Approach
Use the guidelines provided in http://maven.apache.org/guides/mini/guide-naming-conventions.html to name the artifacts. 

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.