### PR TITLE
Fix maximum file upload issue

### DIFF
--- a/internal/scan-manager/webapp/src/main/resources/application.properties
+++ b/internal/scan-manager/webapp/src/main/resources/application.properties
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-spring.http.multipart.maxFileSize=2000MB
-spring.http.multipart.max-request-size=20000MB
-spring.http.multipart.enabled=true
-spring.http.multipart.location=${user.dir}
+spring.servlet.multipart.max-file-size=2000MB
+spring.servlet.multipart.max-request-size=20000MB
+spring.servlet.multipart.enabled=true
+spring.servlet.multipart.location=${user.dir}
 server.tomcat.additional-tld-skip-patterns= jaxb-*.jar
 logging.level.org.springframework.web=INFO
 


### PR DESCRIPTION
## Purpose

Issue occurred when uploading large file than the size that spring boot supports by default. This is occurred due to the upgraded spring boot version. In upgraded spring boot version, property name for maximum file upload size has been changed. By changing this property name we can resolve this issue.

Resolves : https://github.com/wso2-enterprise/security-artifacts/issues/354

